### PR TITLE
change command, fix hstream-client ctrl-c behavior 

### DIFF
--- a/hstream/client/Main.hs
+++ b/hstream/client/Main.hs
@@ -88,7 +88,7 @@ main = do
       (liftIO $ readIORef clientState) >>= \case
         Just taskName -> do
           let createRequest api = liftIO $ parseRequest (cHttpUrl ++ ":" ++ show cServerPort ++ api)
-          createRequest ("/terminate/queryByName/" ++ taskName) >>= handleReq @Resp Proxy
+          _ <- createRequest ("/terminate/queryByName/" ++ taskName) >>= httpBS
           liftIO $ writeIORef clientState Nothing
           loop c clientState
         Nothing -> do

--- a/hstream/src/HStream/Server/Api.hs
+++ b/hstream/src/HStream/Server/Api.hs
@@ -12,6 +12,7 @@ type ServerApi = StreamApi
 type StreamApi =
     "show" :> "queries" :> Get '[JSON] [TaskInfo]
     :<|> "create" :> "query" :> ReqBody '[JSON] ReqSQL :> Post '[JSON] (Either String TaskInfo)
-    :<|> "delete" :> "query" :> Capture "query id" TaskID :> Get '[JSON] Resp
+    :<|> "terminate" :> "query" :> Capture "query id" TaskID :> Get '[JSON] Resp
     :<|> "create" :> "stream" :> "query" :> Capture "query name" Text :> ReqBody '[JSON] ReqSQL :> StreamPost NoFraming OctetStream (SourceIO RecordStream)
-    :<|> "delete" :> "query" :> "all" :> Get '[JSON] Resp
+    :<|> "terminate" :> "query" :> "all" :> Get '[JSON] Resp
+    :<|> "terminate" :> "queryByName" :> Capture "query name" Text :> Get '[JSON] Resp

--- a/hstream/src/HStream/Server/Handler.hs
+++ b/hstream/src/HStream/Server/Handler.hs
@@ -82,7 +82,7 @@ handleException State{..} (Just req) se
               tns <- readIORef taskNameMap
               tks <- readIORef taskMap
               case M.lookup taskName tns >>= flip M.lookup tks of
-                Nothing -> error "error happened"
+                Nothing -> return ()
                 Just (Just a, CreateStream{}) -> do
                   cancel a
                   atomicModifyIORef' taskNameMap (\t -> (M.delete taskName t, ()))
@@ -140,7 +140,7 @@ handleTerminateTaskByName taskName = do
   tns <- readIORef taskNameMap
   tks <- readIORef taskMap
   case M.lookup taskName tns >>= flip M.lookup tks of
-    Nothing -> error "error happened"
+    Nothing -> return $ OK ""
     Just (Just a, CreateStream{}) -> do
       cancel a
       atomicModifyIORef' taskNameMap (\t -> (M.delete taskName t, ()))

--- a/hstream/src/HStream/Server/Type.hs
+++ b/hstream/src/HStream/Server/Type.hs
@@ -79,6 +79,8 @@ data ClientConfig = ClientConfig
   }
   deriving (Show)
 
+type ClientState = IORef (Maybe String)
+
 data State = State
   { taskMap             :: IORef (Map TaskID (Maybe (Async TaskState), TaskInfo)),
     taskNameMap         :: IORef (Map Text TaskID),


### PR DESCRIPTION
change the command 'delete to 'terminate';
fix hstream-client ctrl-c behavior: When the client presses ctrl-c while executing the 'SELECT XXX' command, the server will immediately terminate the query task.