### PR TITLE
Add persistence

### DIFF
--- a/hstream-server/app/Server.hs
+++ b/hstream-server/app/Server.hs
@@ -4,18 +4,25 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
+import           Control.Exception
+import           Control.Monad
 import           HStream.Server.HStreamApi
 import           HStream.Server.Handler
+import           HStream.Server.Persistence
 import           Network.GRPC.HighLevel.Generated
-
 import           Options.Applicative
 import           Z.Data.CBytes                    (CBytes, toBytes)
 import           Z.Foreign                        (toByteString)
 import           Z.IO.Network
+import           ZooKeeper
+import           ZooKeeper.Exception
+import           ZooKeeper.Types
 
 data ServerConfig = ServerConfig
   { _serverHost          :: CBytes
   , _serverPort          :: PortNumber
+  , _zkHost              :: CBytes
+  , _zkPort              :: CBytes
   , _logdeviceConfigPath :: CBytes
   , _topicRepFactor      :: Int
   } deriving (Show)
@@ -23,23 +30,29 @@ data ServerConfig = ServerConfig
 parseConfig :: Parser ServerConfig
 parseConfig =
   ServerConfig
-    <$> strOption   (long "host" <> metavar "HOST" <> showDefault <> value "127.0.0.1" <> help "server host value")
-    <*> option auto (long "port" <> metavar "INT" <> showDefault <> value 6570 <> short 'p' <> help "server port value")
-    <*> strOption (long "config-path" <> metavar "PATH" <> showDefault <> value "/data/store/logdevice.conf" <> help "logdevice config path")
-    <*> option auto (long "replicate-factor" <> metavar "INT" <> showDefault <> value 3 <> short 'f' <> help "topic replicate factor")
+    <$> strOption   (long "host"             <> metavar "HOST" <> showDefault <> value "127.0.0.1"                  <> help "server host value")
+    <*> option auto (long "port"             <> metavar "INT"  <> showDefault <> value 6570 <> short 'p'            <> help "server port value")
+    <*> strOption   (long "zkhost"           <> metavar "HOST" <> showDefault <> value "0.0.0.0"                    <> help "zookeeper host value")
+    <*> strOption   (long "zkport"           <> metavar "INT"  <> showDefault <> value "2181" <> short 'p'          <> help "zookeeper port value")
+    <*> strOption   (long "config-path"      <> metavar "PATH" <> showDefault <> value "/data/store/logdevice.conf" <> help "logdevice config path")
+    <*> option auto (long "replicate-factor" <> metavar "INT"  <> showDefault <> value 3 <> short 'f'               <> help "topic replicate factor")
 
 app :: ServerConfig -> IO ()
-app ServerConfig{..} = do
+app ServerConfig{..} = withResource (defaultHandle (_zkHost <> ":" <> _zkPort)) $ \zk -> do
+  initZooKeeper zk
   let options = defaultServiceOptions
                 { serverHost = Host . toByteString . toBytes $ _serverHost
                 , serverPort = Port . fromIntegral $ _serverPort
                 }
-  api <- handlers _logdeviceConfigPath
+  api <- handlers _logdeviceConfigPath zk
   print _logdeviceConfigPath
   hstreamApiServer api options
+
+initZooKeeper :: ZHandle -> IO ()
+initZooKeeper zk = catch (initializeAncestors zk) (\e -> void $ return (e :: ZNODEEXISTS))
 
 main :: IO ()
 main = do
   config <- execParser $ info (parseConfig <**> helper) (fullDesc <> progDesc "HStream-Server")
-  print "HStream Server"
+  putStrLn "HStream Server"
   app config

--- a/hstream-server/hstream-server.cabal
+++ b/hstream-server/hstream-server.cabal
@@ -76,6 +76,7 @@ executable hstream-server
     , vector
     , Z-Data
     , Z-IO
+    , zoovisitor
 
   hs-source-dirs:   app
   ghc-options:

--- a/hstream-server/hstream-server.cabal
+++ b/hstream-server/hstream-server.cabal
@@ -24,6 +24,7 @@ library
     HStream.Server.Handler
     HStream.Server.HStoreConnector
     HStream.Server.HStreamApi
+    HStream.Server.Persistence
     HStream.Server.Utils
     ThirdParty.Google.Protobuf.Struct
 
@@ -51,6 +52,7 @@ library
     , vector
     , Z-Data
     , Z-IO
+    , zoovisitor
 
   default-language: Haskell2010
   ghc-options:

--- a/hstream-server/src/HStream/Server/HStoreConnector.hs
+++ b/hstream-server/src/HStream/Server/HStoreConnector.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE StrictData         #-}
 
-
 module HStream.Server.HStoreConnector
   ( hstoreSourceConnector
   , hstoreSinkConnector
@@ -94,8 +93,8 @@ writeRecordToHStore ldclient SinkRecord{..} = do
   let payload =
         Payload {
           pTimestamp = snkTimestamp,
-          pKey = fmap lazyByteStringToCbytes snkKey,
-          pValue = lazyByteStringToCbytes snkValue
+          pKey = fmap lazyByteStringToCBytes snkKey,
+          pValue = lazyByteStringToCBytes snkValue
         }
   -- FIXME: for some unknown reasons, github action will exit failure without
   -- any information out if we evaluate the payload. So we here always print the

--- a/hstream-server/src/HStream/Server/Persistence.hs
+++ b/hstream-server/src/HStream/Server/Persistence.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+module HStream.Server.Persistence where
+
+import           Control.Exception
+import           Control.Monad     (void)
+import           Data.Int          (Int64)
+import           GHC.Generics      (Generic)
+import           Z.Data.CBytes     (CBytes)
+import           Z.Data.JSON       (JSON, decode, encode)
+import           Z.Data.Text       (Text)
+import           Z.Data.Vector     (Bytes)
+import           Z.IO.Exception    (HasCallStack)
+import           Z.IO.Time         (SystemTime (..), getSystemTime')
+import           ZooKeeper
+import           ZooKeeper.Types
+
+type SqlStatement = Text
+type QueryId      = CBytes
+type TimeStamp    = Int64
+
+data QueryInfo = QueryInfo {
+    sqlStatement :: SqlStatement
+  , createdTime  :: TimeStamp
+} deriving (Generic, Show)
+instance JSON QueryInfo
+
+data QueryStatus = QueryStatus {
+    queryStatus         :: QStatus
+  , queryTimeCheckpoint :: TimeStamp
+} deriving (Generic, Show)
+instance JSON QueryStatus
+
+data QStatus = QCreated
+  | QRunning
+  | QTerminated
+  deriving (Show, Eq, Generic)
+instance JSON QStatus
+
+queriesPath :: CBytes
+queriesPath = "/hstreamdb/hstream/queries"
+
+defaultHandle :: HasCallStack => Resource ZHandle
+defaultHandle = zookeeperResInit "0.0.0.0:2182" 2500 Nothing 0
+
+insertQuery :: HasCallStack => ZHandle -> QueryId -> QueryInfo -> IO ()
+insertQuery zk qid info@(QueryInfo _ timestamp) = do
+  createPath   zk (mkPath qid)
+  createInsert zk (mkPath qid <> "/details") (encode info)
+  createInsert zk (mkPath qid <> "/status")  (encode $ QueryStatus QCreated timestamp)
+
+setStatus :: HasCallStack => ZHandle -> QueryId -> QStatus -> IO ()
+setStatus zk qid status = do
+    MkSystemTime timestamp _ <- getSystemTime'
+    setQuery zk (qid <> "/status") (encode $ QueryStatus status timestamp)
+
+getQueries :: HasCallStack => ZHandle -> IO [(QueryInfo, QueryStatus)]
+getQueries zk = do
+  StringsCompletion (StringVector qids) <- zooGetChildren zk queriesPath
+  details <- mapM ((decodeQ <$>) . zooGet zk . (<> "/details") . mkPath) qids
+  status  <- mapM ((decodeQ <$>) . zooGet zk . (<> "/status")  . mkPath) qids
+  return $ zip details status
+
+--------------------------------------------------------------------------------
+
+initializeAncestors :: HasCallStack => ZHandle -> IO ()
+initializeAncestors zk = createPath zk "/hstreamdb"
+  >> createPath zk "/hstreamdb/hstream" >> createPath zk queriesPath
+
+createInsert :: HasCallStack => ZHandle -> CBytes -> Bytes -> IO ()
+createInsert zk path contents =
+  void $ zooCreate zk path (Just contents) zooOpenAclUnsafe ZooPersistent
+
+setQuery :: HasCallStack => ZHandle -> CBytes -> Bytes -> IO ()
+setQuery zk path contents =
+  void $ zooSet zk (queriesPath <> path) (Just contents) Nothing
+
+--------------------------------------------------------------------------------
+
+createPath :: HasCallStack => ZHandle -> CBytes -> IO ()
+createPath zk path =
+  void $ zooCreate zk path Nothing zooOpenAclUnsafe ZooPersistent
+
+decodeQ :: JSON a => DataCompletion -> a
+decodeQ = (\case { Right x -> x ; _ -> error "decoding failed"}) . snd . decode
+        . (\case { Nothing -> ""; Just x -> x}) . dataCompletionValue
+
+mkPath :: QueryId -> CBytes
+mkPath x = queriesPath <> "/" <> x

--- a/hstream-server/src/HStream/Server/Utils.hs
+++ b/hstream-server/src/HStream/Server/Utils.hs
@@ -1,12 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms   #-}
 module HStream.Server.Utils
   ( jsonObjectToStruct
   , jsonValueToValue
   , structToJsonObject
   , valueToJsonValue
+  , zJsonObjectToStruct
+  , zJsonValueToValue
+  , structToZJsonObject
+  , valueToZJsonValue
   , cbytesToText
   , textToCBytes
-  , lazyByteStringToCbytes
+  , lazyByteStringToCBytes
   , cbytesToLazyByteString
   , cbytesToValue
   , listToStruct
@@ -19,45 +24,80 @@ import qualified Data.Map                          as M
 import qualified Data.Map.Strict                   as Map
 import           Data.Scientific
 import qualified Data.Text.Lazy                    as TL
-import           Data.Vector                       (fromList)
+import qualified Data.Vector                       as V
+
 import           Proto3.Suite
 import qualified RIO.ByteString.Lazy               as BL
 import qualified RIO.Text                          as T
 import           ThirdParty.Google.Protobuf.Struct
 import qualified Z.Data.CBytes                     as ZCB
-import           Z.Data.Vector.Base                (Bytes)
+import qualified Z.Data.JSON                       as Z
+import qualified Z.Data.Text                       as ZT
+import qualified Z.Data.Vector                     as ZV
 import qualified Z.Foreign                         as ZF
 
--- Aeson.Value  <-> PB.Value
--- Aeson.Object <-> PB.Struct
+pattern V x = Value (Just x)
 
 jsonObjectToStruct :: Aeson.Object -> Struct
 jsonObjectToStruct object = Struct kvmap
-  where kvmap = M.fromList $ map (\(k,v) -> (TL.fromStrict k,Just (jsonValueToValue v))) (HM.toList object)
+  where
+    kvmap = M.fromList $ map (\(k,v) -> (TL.fromStrict k, Just (jsonValueToValue v))) (HM.toList object)
 
 jsonValueToValue :: Aeson.Value -> Value
-jsonValueToValue (Aeson.Object object) = Value (Just $ ValueKindStructValue (jsonObjectToStruct object))
-jsonValueToValue (Aeson.Array  array)  = Value (Just $ ValueKindListValue (ListValue $ jsonValueToValue <$> array))
-jsonValueToValue (Aeson.String text)   = Value (Just $ ValueKindStringValue (TL.fromStrict text))
-jsonValueToValue (Aeson.Number sci)    = Value (Just $ ValueKindNumberValue (toRealFloat sci))
-jsonValueToValue (Aeson.Bool   bool)   = Value (Just $ ValueKindBoolValue bool)
-jsonValueToValue Aeson.Null            = Value (Just $ ValueKindNullValue (Enumerated $ Right NullValueNULL_VALUE))
+jsonValueToValue (Aeson.Object object) = V $ ValueKindStructValue (jsonObjectToStruct object)
+jsonValueToValue (Aeson.Array  array)  = V $ ValueKindListValue   (ListValue $ jsonValueToValue <$> array)
+jsonValueToValue (Aeson.String text)   = V $ ValueKindStringValue (TL.fromStrict text)
+jsonValueToValue (Aeson.Number sci)    = V $ ValueKindNumberValue (toRealFloat sci)
+jsonValueToValue (Aeson.Bool   bool)   = V $ ValueKindBoolValue   bool
+jsonValueToValue Aeson.Null            = V $ ValueKindNullValue   (Enumerated $ Right NullValueNULL_VALUE)
 
 structToJsonObject :: Struct -> Aeson.Object
 structToJsonObject (Struct kvmap) = HM.fromList $
   (\(text,value) -> (TL.toStrict text, convertMaybeValue value)) <$> kvTuples
-  where kvTuples = Map.toList kvmap
-        convertMaybeValue Nothing  = error "Nothing encountered"
-        convertMaybeValue (Just v) = valueToJsonValue v
+  where
+    kvTuples = Map.toList kvmap
+    convertMaybeValue Nothing  = error "Nothing encountered"
+    convertMaybeValue (Just v) = valueToJsonValue v
 
 valueToJsonValue :: Value -> Aeson.Value
 valueToJsonValue (Value Nothing) = error "Nothing encountered"
-valueToJsonValue (Value (Just (ValueKindStructValue struct)))         = Aeson.Object (structToJsonObject struct)
-valueToJsonValue (Value (Just (ValueKindListValue (ListValue list)))) = Aeson.Array (valueToJsonValue <$> list)
-valueToJsonValue (Value (Just (ValueKindStringValue text)))           = Aeson.String (TL.toStrict text)
-valueToJsonValue (Value (Just (ValueKindNumberValue num)))            = Aeson.Number (read . show $ num)
-valueToJsonValue (Value (Just (ValueKindBoolValue bool)))             = Aeson.Bool bool
-valueToJsonValue (Value (Just (ValueKindNullValue _)))                = Aeson.Null
+valueToJsonValue (V (ValueKindStructValue struct))           = Aeson.Object (structToJsonObject struct)
+valueToJsonValue (V (ValueKindListValue   (ListValue list))) = Aeson.Array  (valueToJsonValue <$> list)
+valueToJsonValue (V (ValueKindStringValue text))             = Aeson.String (TL.toStrict text)
+valueToJsonValue (V (ValueKindNumberValue num))              = Aeson.Number (read . show $ num)
+valueToJsonValue (V (ValueKindBoolValue   bool))             = Aeson.Bool   bool
+valueToJsonValue (V (ValueKindNullValue   _))                = Aeson.Null
+
+zJsonObjectToStruct :: ZObject -> Struct
+zJsonObjectToStruct object = Struct kvmap
+ where
+   kvmap = M.fromList $ map (\(k,v) -> (TL.pack $ ZT.unpack k, Just (zJsonValueToValue v))) (ZV.unpack object)
+
+zJsonValueToValue :: Z.Value -> Value
+zJsonValueToValue (Z.Object object) = V $ ValueKindStructValue (zJsonObjectToStruct object)
+zJsonValueToValue (Z.Array  array)  = V $ ValueKindListValue   (ListValue $ V.fromList $ zJsonValueToValue <$> ZV.unpack array)
+zJsonValueToValue (Z.String text)   = V $ ValueKindStringValue (TL.pack $ ZT.unpack text)
+zJsonValueToValue (Z.Number sci)    = V $ ValueKindNumberValue (toRealFloat sci)
+zJsonValueToValue (Z.Bool   bool)   = V $ ValueKindBoolValue   bool
+zJsonValueToValue Z.Null            = V $ ValueKindNullValue   (Enumerated $ Right NullValueNULL_VALUE)
+
+type ZObject = ZV.Vector (ZT.Text, Z.Value)
+structToZJsonObject :: Struct -> ZObject
+structToZJsonObject (Struct kvmap) = ZV.pack $
+  (\(text,value) -> (ZT.pack $ TL.unpack text, convertMaybeValue value)) <$> kvTuples
+  where
+    kvTuples = Map.toList kvmap
+    convertMaybeValue Nothing  = error "Nothing encountered"
+    convertMaybeValue (Just v) = valueToZJsonValue v
+
+valueToZJsonValue :: Value -> Z.Value
+valueToZJsonValue (Value Nothing) = error "Nothing encountered"
+valueToZJsonValue (V (ValueKindStructValue struct))           = Z.Object (structToZJsonObject struct)
+valueToZJsonValue (V (ValueKindListValue   (ListValue list))) = Z.Array  (ZV.pack $ V.toList $ valueToZJsonValue <$> list)
+valueToZJsonValue (V (ValueKindStringValue text))             = Z.String (ZT.pack $ TL.unpack text)
+valueToZJsonValue (V (ValueKindNumberValue num))              = Z.Number (read . show $ num)
+valueToZJsonValue (V (ValueKindBoolValue   bool))             = Z.Bool   bool
+valueToZJsonValue (V (ValueKindNullValue   _))                = Z.Null
 
 cbytesToText :: ZCB.CBytes -> T.Text
 cbytesToText = T.pack . ZCB.unpack
@@ -68,11 +108,11 @@ textToCBytes = ZCB.pack . T.unpack
 cbytesToLazyByteString :: ZCB.CBytes -> BL.ByteString
 cbytesToLazyByteString = BL.fromStrict . ZF.toByteString . ZCB.toBytes
 
-lazyByteStringToCbytes :: BL.ByteString -> ZCB.CBytes
-lazyByteStringToCbytes = ZCB.fromBytes . ZF.fromByteString . BL.toStrict
+lazyByteStringToCBytes :: BL.ByteString -> ZCB.CBytes
+lazyByteStringToCBytes = ZCB.fromBytes . ZF.fromByteString . BL.toStrict
 
 listToStruct :: TL.Text -> [Value] -> Struct
-listToStruct x = Struct . Map.singleton x . Just . Value . Just . ValueKindListValue . ListValue . fromList
+listToStruct x = Struct . Map.singleton x . Just . Value . Just . ValueKindListValue . ListValue . V.fromList
 
 structToStruct :: TL.Text -> Struct -> Struct
 structToStruct x = Struct . Map.singleton x . Just . Value . Just . ValueKindStructValue

--- a/hstream-sql/hstream-sql.cabal
+++ b/hstream-sql/hstream-sql.cabal
@@ -62,6 +62,8 @@ library
     , text                  ^>=1.2
     , time                  >=1.9.1 && <2
     , unordered-containers
+    , uuid
+    , Z-IO
 
   -- Note: build on osx require this
   build-tool-depends: alex:alex -any

--- a/hstream-sql/src/HStream/SQL/AST.hs
+++ b/hstream-sql/src/HStream/SQL/AST.hs
@@ -248,7 +248,7 @@ instance Refine From where
                    cond
                   ]) =
     case refine cond of
-      (RCondOp RCompOpEQ (RExprCol _ (Just s1) f1) (RExprCol _ (Just s2) f2)) ->
+      (RCondOp RCompOpEQ (RExprCol _ (Just s1) f1) (RExprCol _ (Just _) f2)) ->
         case t1 == s1 of
           True  -> RFromJoin (t1,f1) (t2,f2) (refine joinType) (refine win)
           False -> RFromJoin (t1,f2) (t2,f1) (refine joinType) (refine win)
@@ -317,6 +317,7 @@ instance Refine GroupBy where
       ColNameSimple _ (Ident f)           -> RGroupBy Nothing f (Just $ refine win)
       ColNameStream _ (Ident s) (Ident f) -> RGroupBy (Just s) f (Just $ refine win)
       _                                   -> throwSQLException RefineException Nothing "Impossible happened" -- Index and Inner is not supportede
+  refine _ = throwSQLException RefineException Nothing "Impossible happened"
 
 ---- Hav
 data RHaving = RHavingEmpty
@@ -426,5 +427,10 @@ instance Refine SQL where
   refine (QSelect _ select) = RQSelect (refine select)
   refine (QCreate _ create) = RQCreate (refine create)
   refine (QInsert _ insert) = RQInsert (refine insert)
-  refine (QShow   _ show)   = RQShow   (refine show)
-  refine (QDrop   _ drop)   = RQDrop   (refine drop)
+  refine (QShow   _ show_)  = RQShow   (refine show_)
+  refine (QDrop   _ drop_)  = RQDrop   (refine drop_)
+
+--------------------------------------------------------------------------------
+
+throwImpossible :: a
+throwImpossible = throwSQLException RefineException Nothing "Impossible happened"

--- a/hstream-sql/src/HStream/SQL/Codegen/Utils.hs
+++ b/hstream-sql/src/HStream/SQL/Codegen/Utils.hs
@@ -24,7 +24,6 @@ import           Data.Time             (DiffTime, diffTimeToPicoseconds)
 import           HStream.SQL.AST
 import           HStream.SQL.Exception (SomeSQLException (..),
                                         throwSQLException)
-import           Prelude               (read)
 import           RIO
 import           Text.StringRandom     (stringRandomIO)
 

--- a/hstream-sql/src/HStream/SQL/Validate.hs
+++ b/hstream-sql/src/HStream/SQL/Validate.hs
@@ -616,5 +616,5 @@ instance Validate SQL where
   validate sql@(QSelect _ select) = validate select >> return sql
   validate sql@(QCreate _ create) = validate create >> return sql
   validate sql@(QInsert _ insert) = validate insert >> return sql
-  validate sql@(QShow   _ show)   = validate show   >> return sql
-  validate sql@(QDrop   _ drop)   = validate drop   >> return sql
+  validate sql@(QShow   _ show_)  = validate show_   >> return sql
+  validate sql@(QDrop   _ drop_)  = validate drop_   >> return sql

--- a/hstream/HStream/Format.hs
+++ b/hstream/HStream/Format.hs
@@ -3,75 +3,46 @@
 module HStream.Format where
 
 import qualified Data.Aeson                        as A
+import           Data.Aeson.Encode.Pretty
 import qualified Data.Aeson.Text                   as A
 import qualified Data.HashMap.Strict               as HM
 import qualified Data.Map.Strict                   as M
 import           Data.Maybe                        (maybeToList)
 import qualified Data.Text                         as T
 import qualified Data.Text.Lazy                    as TL
+import           Data.Text.Lazy.Builder            (toLazyText)
 import qualified Data.Vector                       as V
 import qualified HStream.SQL.Exception             as E
 import qualified HStream.Server.HStreamApi         as HA
-import           HStream.Server.Utils              (structToJsonObject)
+import           HStream.Server.Utils              (structToJsonObject,
+                                                    structToZJsonObject,
+                                                    valueToJsonValue)
+import           Text.Layout.Table
 import qualified ThirdParty.Google.Protobuf.Struct as P
 
 type Width = Int
-type Box = (Width, String)
-type Row = ([Width], [String])
-type Table = ([Width], [Row])
 
-vBorder :: [Width] -> String
-vBorder = foldr ((++) . (:) '+' . flip replicate '-' . (+ 2)) "+"
+formatResult :: Width -> P.Struct -> String
+formatResult width struct@(P.Struct kv) =
+  case M.toList kv of
+    [("SHOWSTREAMS", Just v)] -> unlines .  words . formatValue $ v
+    [("SHOWQUERIES", Just (P.Value (Just (P.ValueKindListValue (P.ListValue xs)))))] ->
+      renderJSONObjectsToTable width $ getObjects $ map valueToJsonValue $ V.toList xs
+   --   unlines $ map (TL.unpack . toLazyText . encodePrettyToTextBuilder' defConfig {confIndent = Spaces 1} . valueToJsonValue) $ V.toList xs
+    [("SELECT", Just (P.Value (Just (P.ValueKindStructValue struct))))] ->
+      renderJSONObjectToTable width $ structToJsonObject struct
+    x -> show x
 
-box :: String -> Box
-box str = (length str, str)
-
-emptyRow :: ([Width], [String])
-emptyRow = ([],[])
-
-emptyTable :: ([Width], [Row])
-emptyTable = (repeat 0, [])
-
-addBox :: Row -> Box -> Row
-addBox (ws, ss) (w, s)= (w : ws, s : ss)
-
-addRow :: Table -> Row -> Table
-addRow (tws, rs) (rws, ss) = let ws' = zipWith max rws tws in (ws', (ws', ss) : rs)
-
-renderBox :: Box -> String
-renderBox (w, s) = ' ' : s ++ replicate (w + 1 - length s) ' ' ++ "|"
-
-renderRow :: Row -> String
-renderRow (ws, ss) = '|' : (concatMap renderBox . zip ws) ss
-
-renderTable :: Table -> [String]
-renderTable (ws, rs) = vBorder ws : renderTable' rs ++ [vBorder ws]
-  where
-    renderTable' ((_, ss) : rs') = renderRow (ws, ss) : renderTable' rs'
-    renderTable' []              = []
-
-renderJSONObjectToTable :: A.Object -> Table
-renderJSONObjectToTable hmap =
-  emptyTable `addRow` foldr (flip addBox . box . TL.unpack . A.encodeToLazyText) emptyRow elems
-             `addRow` foldr (flip addBox . box . T.unpack) emptyRow keys
-  where
-    keys  = HM.keys hmap
-    elems = HM.elems hmap
-
-renderJSONToTable :: A.Value -> Table
-renderJSONToTable (A.Object hmap) = renderJSONObjectToTable hmap
-renderJSONToTable x = emptyTable `addRow` (emptyRow `addBox` (box . show) x)
-
---------------------------------------------------------------------------------------------------
 formatSomeSQLException :: E.SomeSQLException -> String
-formatSomeSQLException (E.ParseException   info) = "Parse exception " ++ formatParseExceptionInfo info ++ "\n"
-formatSomeSQLException (E.RefineException  info) = "Refine exception at " ++ show info ++ "\n"
-formatSomeSQLException (E.CodegenException info) = "Codegen exception at " ++ show info ++ "\n"
+formatSomeSQLException (E.ParseException   info) = "Parse exception " ++ formatParseExceptionInfo info
+formatSomeSQLException (E.RefineException  info) = "Refine exception at " ++ show info
+formatSomeSQLException (E.CodegenException info) = "Codegen exception at " ++ show info
 
 formatParseExceptionInfo :: E.SomeSQLExceptionInfo -> String
 formatParseExceptionInfo E.SomeSQLExceptionInfo{..} =
   case words sqlExceptionMessage of
-    "syntax" : "error" : "at" : "line" : x : "column" : y : ss  -> "at <line " ++ x ++ "column " ++ y ++ ">: syntax error " ++ unwords ss ++ "."
+    "syntax" : "error" : "at" : "line" : x : "column" : y : ss ->
+      "at <line " ++ x ++ "column " ++ y ++ ">: syntax error " ++ unwords ss ++ "."
     _ -> posInfo ++ sqlExceptionMessage ++ "."
  where
    posInfo = case sqlExceptionPosition of
@@ -80,28 +51,55 @@ formatParseExceptionInfo E.SomeSQLExceptionInfo{..} =
 
 formatCommandQueryResponse :: HA.CommandQueryResponse -> String
 formatCommandQueryResponse (HA.CommandQueryResponse (Just x)) = case x of
-  HA.CommandQueryResponseKindSuccess _ -> "Command successfully executed.\n"
-  HA.CommandQueryResponseKindResultSet (HA.CommandQueryResultSet y) -> (unlines . map ( (++ ".") .formatStruct) . V.toList) y
+  HA.CommandQueryResponseKindSuccess _ ->
+    "Command successfully executed."
+  HA.CommandQueryResponseKindResultSet (HA.CommandQueryResultSet y) ->
+    (unlines . map ( (++ ".") .formatStruct) . V.toList) y
+
+--------------------------------------------------------------------------------
 
 formatStruct :: P.Struct -> String
-formatStruct (P.Struct kv) = unwords . map (\(x, y) -> TL.unpack x ++ (' ' : (concat . maybeToList) y)) . M.toList . fmap (fmap formatValue) $ kv
+formatStruct (P.Struct kv) = unlines . map (\(x, y) -> TL.unpack x ++ (':' : (concat . maybeToList) y))
+                                           . M.toList . fmap (fmap formatValue) $ kv
 
 formatValue :: P.Value -> String
 formatValue (P.Value Nothing)  = ""
 formatValue (P.Value (Just x)) = formatValueKind x
 
 formatValueKind :: P.ValueKind -> String
-formatValueKind (P.ValueKindNullValue _) = "NULL"
+formatValueKind (P.ValueKindNullValue _)   = "NULL"
 formatValueKind (P.ValueKindNumberValue n) = show n
 formatValueKind (P.ValueKindStringValue s) = TL.unpack s
 formatValueKind (P.ValueKindBoolValue   b) = show b
-formatValueKind (P.ValueKindStructValue struct) = formatStruct struct
+formatValueKind (P.ValueKindStructValue s) = formatStruct s
 formatValueKind (P.ValueKindListValue (P.ListValue vs)) = unwords . map formatValue . V.toList $ vs
 
-formatResult :: P.Struct -> String
-formatResult struct@(P.Struct kv) =
-  case M.toList kv of
-    [("SHOW", Just v)] -> unlines .  words . formatValue $ v
-    [("SELECT", Just (P.Value (Just (P.ValueKindStructValue struct))))]
-                -> unlines $ renderTable $ renderJSONObjectToTable $ structToJsonObject struct
-    _           -> formatStruct struct
+--------------------------------------------------------------------------------
+
+renderJSONObjectToTable :: Width -> A.Object -> String
+renderJSONObjectToTable w os = renderJSONObjectsToTable w [os]
+
+renderJSONObjectsToTable :: Width -> [A.Object] -> String
+renderJSONObjectsToTable _ [] = ""
+renderJSONObjectsToTable l os@(o:_) =
+  tableString colout unicodeRoundS (titlesH keys) $
+  map (colsAllG center . renderContents (l `div` (size + 2))) elems
+  where
+    keys  = map T.unpack (HM.keys o)
+    elems = map HM.elems os
+    size  = length keys
+    colout = replicate size
+      $ column (expandUntil $ l `div` (size + 1)) left noAlign (singleCutMark "...")
+
+renderContents :: Width -> [A.Value] -> [[String]]
+renderContents width = map $ concatMap (justifyText width) . lines . TL.unpack . toLazyText
+                           . encodePrettyToTextBuilder' defConfig {confIndent = Spaces 1}
+
+renderJSONToTable :: Width -> A.Value -> String
+renderJSONToTable width (A.Object hmap) = renderJSONObjectToTable width hmap
+renderJSONToTable _ x                   = show x
+
+--------------------------------------------------------------------------------
+
+getObjects vs = [ object | A.Object object <- vs ]
+getObjects :: [A.Value] -> [A.Object]

--- a/hstream/hstream.cabal
+++ b/hstream/hstream.cabal
@@ -27,10 +27,13 @@ source-repository head
 library
   build-depends:
     , aeson
+    , aeson-pretty
+    , ansi-terminal
     , base
     , containers
     , hstream-server
     , hstream-sql
+    , table-layout
     , text
     , unordered-containers
     , vector
@@ -42,6 +45,7 @@ executable hstream-client
   main-is:          Main.hs
   hs-source-dirs:   client
   build-depends:
+    , ansi-terminal
     , base
     , bytestring
     , grpc-haskell


### PR DESCRIPTION
## Description
- Improve CLI format with an external library 
- add zk persistence library to keep all queries executed
- add show queries to show all queries 
- replace task name from "demo" to the hex of current timestamp

## Type of change
New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
TODO 

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code

### Semi-Must
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any **misspellings**

### Optional:
- [ ] My code follows the [**style guidelines**](https://docs.hstream.io/development/haskell-style/) of this project
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
