### PR TITLE
fix the semantic of `Latest` offset

### DIFF
--- a/hstream/src/HStream/Server/HStoreConnector.hs
+++ b/hstream/src/HStream/Server/HStoreConnector.hs
@@ -48,7 +48,7 @@ subscribeToHStoreStream ldclient reader stream startOffset = do
   startLSN <-
         case startOffset of
           Earlist    -> return S.LSN_MIN
-          Latest     -> S.getTailLSN ldclient logId
+          Latest     -> fmap (+1) (S.getTailLSN ldclient logId)
           Offset lsn -> return lsn
   S.ckpReaderStartReading reader logId startLSN S.LSN_MAX
 


### PR DESCRIPTION
A `SELECT` query will get the last message in the database with the old semantic of `Latest` offset. The proper semantic is to start from `tailLSN + 1`.