### PR TITLE
hstore admin: logs remove

### DIFF
--- a/hstream-store/HStream/Store/Exception.hs
+++ b/hstream-store/HStream/Store/Exception.hs
@@ -234,6 +234,9 @@ module HStream.Store.Exception
   , pattern C_WRITE_STREAM_UNKNOWN
   , pattern C_WRITE_STREAM_BROKEN
   , pattern C_WRITE_STREAM_IGNORED
+
+  -- * Auxiliary functions
+  , isNotFound
   ) where
 
 import           Control.Exception            (Exception (..))
@@ -574,3 +577,6 @@ throwSubmitIfNotOK ret = if ret == 0 then return 0 else throwSubmitError callSta
 throwStoreError :: T.Text -> CallStack -> IO a
 throwStoreError desc stack =
   E.throwIO $ StoreError (SSEInfo "1000" desc stack)
+
+isNotFound :: NOTFOUND -> Bool
+isNotFound = const True

--- a/hstream-store/admin/HStream/Store/Admin/Types.hs
+++ b/hstream-store/admin/HStream/Store/Admin/Types.hs
@@ -259,12 +259,15 @@ data LogsConfigCmd
   | ShowCmd
   | RenameCmd CBytes CBytes Bool
   | CreateCmd CreateLogsOpts
+  | RemoveCmd RemoveLogsOpts
   deriving (Show)
 
 logsConfigCmdParser :: Parser LogsConfigCmd
 logsConfigCmdParser = hsubparser $
-    command "info" (info (InfoCmd <$> logIDParser) (progDesc "Get current attributes of the tail/head of the log"))
- <> command "show" (info (pure ShowCmd) (progDesc "Print the full logsconfig for this tier "))
+    command "info" (info (InfoCmd <$> logIDParser)
+                         (progDesc "Get current attributes of the tail/head of the log"))
+ <> command "show" (info (pure ShowCmd)
+                         (progDesc "Print the full logsconfig for this tier "))
  <> command "create" (info (CreateCmd <$> createLogsParser)
                            (progDesc ("Creates a log group under a specific directory"
                                    <> " path in the LogsConfig tree. This only works"
@@ -274,6 +277,28 @@ logsConfigCmdParser = hsubparser $
                                       <*> strOption (long "new-name" <> metavar "PATH")
                                       <*> flag True False (long "warning"))
                            (progDesc "Renames a path in logs config to a new path"))
+ <> command "remove" (info (RemoveCmd <$> removeLogsOptsParser)
+                           (progDesc ("Removes a directory or a log-group under"
+                            <> " a specific directory path in the LogsConfig tree."
+                            <> " This will NOT delete the directory if it is not"
+                            <> " empty by default, you need to use --recursive."))
+                     )
+
+data RemoveLogsOpts = RemoveLogsOpts
+  { rmPath      :: CBytes
+  , rmRecursive :: Bool
+  } deriving (Show)
+
+removeLogsOptsParser :: Parser RemoveLogsOpts
+removeLogsOptsParser = RemoveLogsOpts
+    <$> strOption ( long "path"
+                  <> metavar "PATH"
+                  <> help "Path of the directory to be removed."
+                  )
+    <*> switch ( long "recursive"
+               <> short 'r'
+               <> help "Whether to remove the contents of the directory if it is not empty or not."
+               )
 
 logIDParser :: Parser S.C_LogID
 logIDParser = option auto (long "id")


### PR DESCRIPTION
# Pull Request Template

## Description

hstore admin functionality: remove a log group or a log directory.

Fixes #219 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```
>>> cabal run -- hstore-admin --port 46003 logs remove --path "test/"
NOTFOUND
>>>cabal run -- hstore-admin --port 46003 logs create --path "test/" --directory
SUCCESS
>>>cabal run -- hstore-admin --port 46003 logs create --path "test/group" --from 111 --to 123
SUCCESS
>>>cabal run -- hstore-admin --port 46003 logs remove --path "test/group"
SUCCESS
>>>cabal run -- hstore-admin --port 46003 logs remove --path "test/group"
NOTFOUND
>>>cabal run -- hstore-admin --port 46003 logs create --path "test/group" --from 111 --to 123
SUCCESS
>>>cabal run -- hstore-admin --port 46003 logs remove --path "test/" --recursive
SUCCESS
>>>cabal run -- hstore-admin --port 46003 logs remove --path "test/group"
NOTFOUND
```

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

### Semi-Must
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any **misspellings**

### Optional:
- [ ] My code follows the [**style guidelines**](https://docs.hstream.io/development/haskell-style/) of this project
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
