### PR TITLE
hstore admin: command `logs show`

### DIFF
--- a/hstream-store/HStream/Store/Internal/LogDevice/LogConfigTypes.hs
+++ b/hstream-store/HStream/Store/Internal/LogDevice/LogConfigTypes.hs
@@ -67,30 +67,27 @@ updateLogAttrsExtrasPtr attrs' logExtraAttrs = do
     Z.withPrimArrayListUnsafe vs $ \vs' _ -> do
       c_update_log_attrs_extras attrs' l ks' vs'
 
-ldLogAttrsToHsLogAttrs :: LDLogAttrs -> IO HsLogAttrs
-ldLogAttrsToHsLogAttrs attrs =
-  liftA2 HsLogAttrs (getAttributeReplicationFactor attrs) (getAttributeExtras attrs)
+hsLogAttrsFromPtr :: Ptr LogDeviceLogAttributes -> IO HsLogAttrs
+hsLogAttrsFromPtr attrs =
+  liftA2 HsLogAttrs (getAttrsReplicationFactorFromPtr attrs) (getAttrsExtrasFromPtr attrs)
 
 logGroupGetHsLogAttrs :: LDLogGroup -> IO HsLogAttrs
 logGroupGetHsLogAttrs group =
-  withForeignPtr group $ \group' ->
-    c_ld_loggroup_get_attrs group' >>= newForeignPtr_ >>= ldLogAttrsToHsLogAttrs
+  withForeignPtr group $ hsLogAttrsFromPtr <=< c_ld_loggroup_get_attrs
 
 logDirectoryGetHsLogAttrs :: LDDirectory -> IO HsLogAttrs
 logDirectoryGetHsLogAttrs dir =
-  withForeignPtr dir $ \dir' ->
-    c_ld_logdirectory_get_attrs dir' >>= newForeignPtr_ >>= ldLogAttrsToHsLogAttrs
+  withForeignPtr dir $ hsLogAttrsFromPtr <=< c_ld_logdirectory_get_attrs
 
-getAttributeExtras :: LDLogAttrs -> IO (Map.Map CBytes CBytes)
-getAttributeExtras attrs =
-  withForeignPtr attrs $ \attrs' -> do
+getAttrsExtrasFromPtr :: Ptr LogDeviceLogAttributes -> IO (Map.Map CBytes CBytes)
+getAttrsExtrasFromPtr attrs = do
   (len, (keys_ptr, (values_ptr, (keys_vec, (values_vec, _))))) <-
     Z.withPrimUnsafe (0 :: Int) $ \len ->
     Z.withPrimUnsafe nullPtr $ \keys ->
     Z.withPrimUnsafe nullPtr $ \values ->
     Z.withPrimUnsafe nullPtr $ \keys_vec ->
     Z.withPrimUnsafe nullPtr $ \values_vec ->
-      c_get_attribute_extras attrs' len keys values keys_vec values_vec
+      c_get_attribute_extras attrs len keys values keys_vec values_vec
   finally
     (buildExtras len keys_ptr values_ptr)
     (delete_vector_of_string keys_vec <> delete_vector_of_string values_vec)
@@ -100,9 +97,8 @@ getAttributeExtras attrs =
       values <- peekStdStringToCBytesN len values_ptr
       return . Map.fromList $ zip keys values
 
-getAttributeReplicationFactor :: LDLogAttrs -> IO Int
-getAttributeReplicationFactor attrs =
-  withForeignPtr attrs (fmap fromIntegral <$> c_get_replication_factor)
+getAttrsReplicationFactorFromPtr :: Ptr LogDeviceLogAttributes -> IO Int
+getAttrsReplicationFactorFromPtr attrs = fromIntegral <$> c_get_replication_factor attrs
 
 foreign import ccall unsafe "hs_logdevice.h get_attribute_extras"
   c_get_attribute_extras :: Ptr LogDeviceLogAttributes
@@ -114,8 +110,7 @@ foreign import ccall unsafe "hs_logdevice.h get_attribute_extras"
                          -> IO ()
 
 foreign import ccall unsafe "hs_logdevice.h get_replication_factor"
-  c_get_replication_factor :: Ptr LogDeviceLogAttributes
-                           -> IO CInt
+  c_get_replication_factor :: Ptr LogDeviceLogAttributes -> IO CInt
 
 -------------------------------------------------------------------------------
 -- LogHeadAttributes
@@ -322,10 +317,9 @@ logDirLogFullName dir name =
     CBytes.withCBytesUnsafe name $ \name' ->
       CBytes.fromCString =<< c_ld_logdir_log_full_name dir' name'
 
--- Note that this pointer is only valiad if LogDirectory is valiad.
+-- Note that this pointer is only valid if LogDirectory is valid.
 logDirectorypGetAttrs :: LDDirectory -> IO (Ptr LogDeviceLogAttributes)
-logDirectorypGetAttrs dir =
-  withForeignPtr dir $ \dir' -> c_ld_logdirectory_get_attrs dir'
+logDirectorypGetAttrs dir = withForeignPtr dir c_ld_logdirectory_get_attrs
 
 foreign import ccall unsafe "hs_logdevice.h ld_logdir_child_full_name"
   c_ld_logdir_child_full_name
@@ -584,10 +578,9 @@ logGroupGetFullName group =
   withForeignPtr group $ CBytes.fromCString <=< c_ld_loggroup_get_fully_qualified_name
 {-# INLINE logGroupGetFullName #-}
 
--- Note that this pointer only valiad if LogGroup is valiad.
+-- Note that this pointer only valid if LogGroup is valid.
 logGroupGetAttrs :: LDLogGroup -> IO (Ptr LogDeviceLogAttributes)
-logGroupGetAttrs group =
-  withForeignPtr group $ \group' -> c_ld_loggroup_get_attrs group'
+logGroupGetAttrs group = withForeignPtr group c_ld_loggroup_get_attrs
 {-# INLINE logGroupGetAttrs #-}
 
 logGroupGetExtraAttr :: LDLogGroup -> CBytes -> IO (Maybe CBytes)

--- a/hstream-store/HStream/Store/Stream.hs
+++ b/hstream-store/HStream/Store/Stream.hs
@@ -22,6 +22,8 @@ module HStream.Store.Stream
     -- * Internal Log
   , FFI.LogID (..)
   , FFI.C_LogID
+  , FFI.LDLogGroup
+  , FFI.LDDirectory
   , LD.getLogGroup
   , LD.getLogGroupByID
   , LD.logGroupGetName

--- a/hstream-store/admin/hstore-admin.cabal
+++ b/hstream-store/admin/hstore-admin.cabal
@@ -99,6 +99,7 @@ library
     , aeson-pretty
     , base                  >=4.11.1   && <4.15
     , bytestring            ^>=0.10.8.2
+    , colourista            ^>=0.1.0.1
     , containers
     , data-default
     , deepseq

--- a/hstream-store/cbits/logdevice/hs_logconfigtypes.cpp
+++ b/hstream-store/cbits/logdevice/hs_logconfigtypes.cpp
@@ -68,13 +68,33 @@ LogAttributes* update_log_attrs_extras(LogAttributes* attrs, HsInt extras_len,
 }
 
 // TODO: macro
-int get_replicationFactor(LogAttributes* attrs) {
+int get_replication_factor(LogAttributes* attrs) {
   return attrs->replicationFactor().value();
 }
 
 std::string* describe_log_maxWritesInFlight(LogAttributes* attrs) {
   return new_hs_std_string(attrs->maxWritesInFlight().describe());
 }
+
+void get_attribute_extras(LogAttributes* attrs, size_t* len,
+                          std::string** keys_ptr, std::string** values_ptr,
+                          std::vector<std::string>** keys_,
+                          std::vector<std::string>** values_) {
+  std::vector<std::string>* keys = new std::vector<std::string>;
+  std::vector<std::string>* values = new std::vector<std::string>;
+  auto& extras = attrs->extras().value();
+
+  for (const auto& [key, value] : extras) {
+    keys->push_back(key);
+    values->push_back(value);
+  }
+
+  *len = keys->size();
+  *keys_ptr = keys->data();
+  *values_ptr = values->data();
+  *keys_ = keys;
+  *values_ = values;
+ }
 
 // ----------------------------------------------------------------------------
 // LogHeadAttributes

--- a/hstream-store/cbits/logdevice/hs_logconfigtypes.cpp
+++ b/hstream-store/cbits/logdevice/hs_logconfigtypes.cpp
@@ -82,11 +82,14 @@ void get_attribute_extras(LogAttributes* attrs, size_t* len,
                           std::vector<std::string>** values_) {
   std::vector<std::string>* keys = new std::vector<std::string>;
   std::vector<std::string>* values = new std::vector<std::string>;
-  auto& extras = attrs->extras().value();
 
-  for (const auto& [key, value] : extras) {
-    keys->push_back(key);
-    values->push_back(value);
+  if (attrs->extras().hasValue()) {
+    auto& extras = attrs->extras().value();
+
+    for (const auto& [key, value] : extras) {
+      keys->push_back(key);
+      values->push_back(value);
+    }
   }
 
   *len = keys->size();
@@ -462,6 +465,11 @@ ld_logdirectory_full_name(logdevice_logdirectory_t* dir) {
 // LogDirectory attrs : version
 uint64_t ld_logdirectory_get_version(logdevice_logdirectory_t* dir) {
   return dir->rep->version();
+}
+
+const LogAttributes* ld_logdirectory_get_attrs(logdevice_logdirectory_t* dir) {
+  const LogAttributes& attrs = dir->rep->attrs();
+  return &attrs;
 }
 
 #define LD_LOGDIRECTORY_MAP_ATTR(NAME, ATTR_NAME, RET_TYPE, FIND_FUN, NOT_FUN) \

--- a/hstream-store/include/hs_logdevice.h
+++ b/hstream-store/include/hs_logdevice.h
@@ -389,6 +389,8 @@ ld_client_get_directory(logdevice_client_t* client, const char* path,
                         facebook::logdevice::Status* st_out,
                         logdevice_logdirectory_t** logdir_result);
 
+const LogAttributes* ld_logdirectory_get_attrs(logdevice_logdirectory_t* dir);
+
 // LogGroup
 facebook::logdevice::Status ld_client_make_loggroup_sync(
     logdevice_client_t* client, const char* path, const c_logid_t start_logid,

--- a/hstream-store/include/hs_logdevice.h
+++ b/hstream-store/include/hs_logdevice.h
@@ -172,6 +172,10 @@ LogAttributes* new_log_attributes(int replicationFactor, HsInt extras_len,
 void free_log_attributes(LogAttributes* attrs);
 bool exist_log_attrs_extras(LogAttributes* attrs, char* key);
 std::string* get_log_attrs_extra(LogAttributes* attrs, char* key);
+void get_attribute_extras(LogAttributes* attrs, size_t* len,
+                          std::string** keys_ptr, std::string** values_ptr,
+                          std::vector<std::string>** keys_,
+                          std::vector<std::string>** values_);
 
 // LogSequenceNumber
 typedef uint64_t c_lsn_t;

--- a/hstream-store/test/HStream/Store/LogDeviceSpec.hs
+++ b/hstream-store/test/HStream/Store/LogDeviceSpec.hs
@@ -2,6 +2,7 @@ module HStream.Store.LogDeviceSpec where
 
 import           Data.List                        (sort)
 import qualified Data.Map.Strict                  as Map
+import           Foreign                          (newForeignPtr_)
 import qualified HStream.Store                    as S
 import qualified HStream.Store.Internal.LogDevice as I
 import           HStream.Store.SpecUtils
@@ -67,3 +68,15 @@ configType = describe "LogConfigType" $ do
     nameB `shouldBe` dirname <> "/B"
     I.syncLogsConfigVersion client =<< I.removeLogDirectory client dirname True
     I.getLogDirectory client dirname `shouldThrow` anyException
+
+  it "log group get attrs" $ do
+    let attrs = S.LogAttrs S.HsLogAttrs { S.logReplicationFactor = 1
+                                        , S.logExtraAttrs = Map.fromList [("A", "B")]
+                                        }
+        logid = 101
+    lg <- I.makeLogGroup client "lg" logid logid attrs False
+    _ <- I.syncLogsConfigVersion client =<< I.logGroupGetVersion lg
+    attrs' <- I.ldLogAttrsToHsLogAttrs =<< newForeignPtr_ =<< I.logGroupGetAttrs lg
+    _ <- I.removeLogGroup client "lg"
+    S.logReplicationFactor attrs' `shouldBe` 1
+    Map.lookup "A" (S.logExtraAttrs attrs') `shouldBe` Just "B"

--- a/hstream-store/test/HStream/Store/LogDeviceSpec.hs
+++ b/hstream-store/test/HStream/Store/LogDeviceSpec.hs
@@ -2,7 +2,6 @@ module HStream.Store.LogDeviceSpec where
 
 import           Data.List                        (sort)
 import qualified Data.Map.Strict                  as Map
-import           Foreign                          (newForeignPtr_)
 import qualified HStream.Store                    as S
 import qualified HStream.Store.Internal.LogDevice as I
 import           HStream.Store.SpecUtils
@@ -76,7 +75,7 @@ configType = describe "LogConfigType" $ do
         logid = 101
     lg <- I.makeLogGroup client "lg" logid logid attrs False
     _ <- I.syncLogsConfigVersion client =<< I.logGroupGetVersion lg
-    attrs' <- I.ldLogAttrsToHsLogAttrs =<< newForeignPtr_ =<< I.logGroupGetAttrs lg
+    attrs' <- I.logGroupGetHsLogAttrs lg
     _ <- I.removeLogGroup client "lg"
     S.logReplicationFactor attrs' `shouldBe` 1
     Map.lookup "A" (S.logExtraAttrs attrs') `shouldBe` Just "B"


### PR DESCRIPTION
## Description

Added HStore Admin command `logs show`

Fixes #221 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```
>>>cabal run -- hstore-admin --port 44439 logs create --path "/group" --from 123 --to 123 --extra-attributes "A":"B"
SUCCESS
>>>cabal run -- hstore-admin --port 44439 logs show -v
- /
  Version: 373662155212
  * /test_logs (1..100)
    Version: 373662155212
    Attributes:
    - replication factor: 2
  * /group (123..123)
    Version: 373662155212
    Attributes:
    - replication factor: 3
    - A: B
  - /hstream/
    Version: 373662155212
  - /ci/
    Version: 373662155212
    - /ci/stream/
      Version: 373662155212

>>>cabal run -- hstore-admin --port 44439 logs show
- /
  * /test_logs (1..100)
  * /group (123..123)
  - /hstream/
  - /ci/
    - /ci/stream/

>>>cabal run -- hstore-admin --port 44439 logs show --id 123 -v
* /group (123..123)
  Version: 373662155212
  Attributes:
  - replication factor: 3
  - A: B

>>>cabal run -- hstore-admin --port 44439 logs show --path "/group" -v
* /group (123..123)
  Version: 373662155212
  Attributes:
  - replication factor: 3
  - A: B

>>>cabal run -- hstore-admin --port 44439 logs show --max-depth 1
- /
  * /group (123..123)
  * /test_logs (1..100)
  - /hstream/
  - /ci/
```
## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

