### PR TITLE
hstore api: logGroupSetRange

### DIFF
--- a/hstream-store/HStream/Store/Internal/Foreign.hs
+++ b/hstream-store/HStream/Store/Internal/Foreign.hs
@@ -93,9 +93,9 @@ withAsync size peek_data f = fst <$> withAsync' size peek_data E.throwStreamErro
 withAsync'
   :: HasCallStack
   => Int -> (Ptr a -> IO a)
-  -> (HasCallStack => b -> IO b)
+  -> (HasCallStack => b -> IO c)
   -> (StablePtr PrimMVar -> Int -> Ptr a -> IO b)
-  -> IO (a, b)
+  -> IO (a, c)
 withAsync' size peek_data g f = mask_ $ do
   mvar <- newEmptyMVar
   sp <- newStablePtrPrimMVar mvar

--- a/hstream-store/HStream/Store/Internal/LogDevice/LogConfigTypes.hs
+++ b/hstream-store/HStream/Store/Internal/LogDevice/LogConfigTypes.hs
@@ -615,6 +615,43 @@ logGroupGetVersion :: LDLogGroup -> IO C_LogsConfigVersion
 logGroupGetVersion group = withForeignPtr group c_ld_loggroup_get_version
 {-# INLINE logGroupGetVersion #-}
 
+-- | This sets the log group range to the supplied new range.
+--
+-- Throw one of the following exceptions on failure:
+--
+-- * E::ID_CLASH - the ID range clashes with existing log group.
+-- * E::NOTFOUND if the path doesn't exist or it's pointing to a directory
+-- * E::INVALID_ATTRIBUTES the range you supplied is invalid or reserved for system-logs.
+-- * E::TIMEDOUT Operation timed out.
+-- * E::ACCESS you don't have permissions to mutate the logs configuration.
+logGroupSetRange :: LDClient
+  -> CBytes
+  -- ^ The path to the log group
+  -> C_LogRange
+  -- ^ The new range to be set
+  -> IO C_LogsConfigVersion
+  -- ^ Return the version of the logsconfig at which the range got updated
+logGroupSetRange client path (start, end) =
+  withForeignPtr client $ \client' ->
+    CBytes.withCBytesUnsafe path $ \path' -> do
+    let size = logsConfigStatusCbDataSize
+        peek_data = peekLogsConfigStatusCbData
+        cfun = c_ld_client_set_log_group_range client' path' start end
+    (LogsConfigStatusCbData errno version _, _) <-
+      withAsync' size peek_data (E.throwSubmitIfNotOK . fromIntegral) cfun
+    void $ E.throwStreamErrorIfNotOK' errno
+    return version
+
+foreign import ccall unsafe "hs_logdevice.h ld_client_set_log_group_range"
+  c_ld_client_set_log_group_range
+    :: Ptr LogDeviceClient
+    -> BA# Word8
+    -> C_LogID
+    -> C_LogID
+    -> StablePtr PrimMVar -> Int
+    -> Ptr LogsConfigStatusCbData
+    -> IO CInt
+
 foreign import ccall unsafe "hs_logdevice.h ld_client_make_loggroup"
   c_ld_client_make_loggroup
     :: Ptr LogDeviceClient

--- a/hstream-store/HStream/Store/Internal/LogDevice/LogConfigTypes.hs
+++ b/hstream-store/HStream/Store/Internal/LogDevice/LogConfigTypes.hs
@@ -624,7 +624,9 @@ logGroupGetVersion group = withForeignPtr group c_ld_loggroup_get_version
 -- * E::INVALID_ATTRIBUTES the range you supplied is invalid or reserved for system-logs.
 -- * E::TIMEDOUT Operation timed out.
 -- * E::ACCESS you don't have permissions to mutate the logs configuration.
-logGroupSetRange :: LDClient
+logGroupSetRange
+  :: HasCallStack
+  => LDClient
   -> CBytes
   -- ^ The path to the log group
   -> C_LogRange

--- a/hstream-store/include/hs_logdevice.h
+++ b/hstream-store/include/hs_logdevice.h
@@ -424,6 +424,11 @@ ld_client_remove_loggroup(logdevice_client_t* client, const char* path,
                           HsStablePtr mvar, HsInt cap,
                           logsconfig_status_cb_data_t* data);
 
+HsInt ld_client_set_log_group_range(logdevice_client_t* client,
+                                    const char* path, c_logid_t start,
+                                    c_logid_t end, HsStablePtr mvar, HsInt cap,
+                                    logsconfig_status_cb_data_t* data);
+
 //-----------------------------------------------------------------------------
 // Log Head Attributes
 

--- a/hstream-store/test/HStream/Store/LogDeviceSpec.hs
+++ b/hstream-store/test/HStream/Store/LogDeviceSpec.hs
@@ -72,10 +72,24 @@ configType = describe "LogConfigType" $ do
     let attrs = S.LogAttrs S.HsLogAttrs { S.logReplicationFactor = 1
                                         , S.logExtraAttrs = Map.fromList [("A", "B")]
                                         }
-        logid = 101
+        logid = 104
     lg <- I.makeLogGroup client "lg" logid logid attrs False
     _ <- I.syncLogsConfigVersion client =<< I.logGroupGetVersion lg
     attrs' <- I.logGroupGetHsLogAttrs lg
     _ <- I.removeLogGroup client "lg"
     S.logReplicationFactor attrs' `shouldBe` 1
     Map.lookup "A" (S.logExtraAttrs attrs') `shouldBe` Just "B"
+
+  it "log group get and set range" $ do
+    let attrs = S.LogAttrs S.HsLogAttrs { S.logReplicationFactor = 1
+                                        , S.logExtraAttrs = Map.fromList [("A", "B")]
+                                        }
+        logid = 105
+        logid' = 106
+    lg <- I.makeLogGroup client "lg" logid logid attrs False
+    range <- I.logGroupGetRange lg
+    range `shouldBe` (logid, logid)
+    _ <- I.logGroupSetRange client "lg" (logid',logid')
+    range' <- I.logGroupGetRange =<< I.getLogGroup client "lg"
+    _ <- I.removeLogGroup client "lg"
+    range' `shouldBe` (logid', logid')

--- a/hstream-store/test/HStream/Store/LogDeviceSpec.hs
+++ b/hstream-store/test/HStream/Store/LogDeviceSpec.hs
@@ -89,7 +89,7 @@ configType = describe "LogConfigType" $ do
     lg <- I.makeLogGroup client "lg" logid logid attrs False
     range <- I.logGroupGetRange lg
     range `shouldBe` (logid, logid)
-    _ <- I.logGroupSetRange client "lg" (logid',logid')
+    I.syncLogsConfigVersion client =<< I.logGroupSetRange client "lg" (logid',logid')
     range' <- I.logGroupGetRange =<< I.getLogGroup client "lg"
-    _ <- I.removeLogGroup client "lg"
+    I.syncLogsConfigVersion client =<< I.removeLogGroup client "lg"
     range' `shouldBe` (logid', logid')


### PR DESCRIPTION
## Description

Implemented a hstore api which will be used by the command `logs set-range`.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

New testcases are added to `LogDeviceSpec.hs`

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

