### PR TITLE
hstore admin: command `logs set-range`

### DIFF
--- a/hstream-store/admin/HStream/Store/Admin/Types.hs
+++ b/hstream-store/admin/HStream/Store/Admin/Types.hs
@@ -262,6 +262,7 @@ data LogsConfigCmd
   | RenameCmd CBytes CBytes Bool
   | CreateCmd CreateLogsOpts
   | RemoveCmd RemoveLogsOpts
+  | SetRangeCmd SetRangeOpts
   deriving (Show)
 
 logsConfigCmdParser :: Parser LogsConfigCmd
@@ -285,6 +286,32 @@ logsConfigCmdParser = hsubparser $
                             <> " This will NOT delete the directory if it is not"
                             <> " empty by default, you need to use --recursive."))
                      )
+ <> command "set-range" (info (SetRangeCmd <$> setRangeOptsParser)
+                              (progDesc ("This updates the log id range for the"
+                               <> " LogGroup under a specific directory path in"
+                               <> " the LogsConfig tree."))
+                        )
+
+data SetRangeOpts = SetRangeOpts
+  { setRangePath    :: CBytes
+  , setRangeStartId :: S.C_LogID
+  , setRangeEndId   :: S.C_LogID
+  } deriving (Show)
+
+setRangeOptsParser :: Parser SetRangeOpts
+setRangeOptsParser = SetRangeOpts
+  <$> strOption ( long "path"
+                <> metavar "PATH"
+                <> help "Path of the the log group."
+                )
+  <*> option auto ( long "from"
+                  <> metavar "INT"
+                  <> help "The beginning of the logid range"
+                  )
+  <*> option auto ( long "to"
+                  <> metavar "INT"
+                  <> help "The end of the logid range"
+                  )
 
 data RemoveLogsOpts = RemoveLogsOpts
   { rmPath      :: CBytes


### PR DESCRIPTION
## Description

Implemented ldshell command `logs set-range` to update the range of a log group.

En route to fixes #274 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

