### PR TITLE
hstore admin: logs info prints whether the log is empty

### DIFF
--- a/hstream-store/HStream/Store.hs
+++ b/hstream-store/HStream/Store.hs
@@ -18,7 +18,7 @@ module HStream.Store
   , getTailLSN
   , trim
   , findTime
-  , doesLogIdHasGroup
+  , logIdHasGroup
 
     -- * Stream
   , module HStream.Store.Stream

--- a/hstream-store/HStream/Store/Internal/LogDevice/LogConfigTypes.hs
+++ b/hstream-store/HStream/Store/Internal/LogDevice/LogConfigTypes.hs
@@ -497,8 +497,8 @@ getLogGroupByID client logid = withForeignPtr client $ \client' -> do
   void $ E.throwStreamErrorIfNotOK' errno
   newForeignPtr c_free_logdevice_loggroup_fun group_ptr
 
-doesLogIdHasGroup :: HasCallStack => LDClient -> C_LogID -> IO Bool
-doesLogIdHasGroup client logid = withForeignPtr client $ \client' -> do
+logIdHasGroup :: HasCallStack => LDClient -> C_LogID -> IO Bool
+logIdHasGroup client logid = withForeignPtr client $ \client' -> do
   (errno, _, _) <- withAsyncPrimUnsafe2 (0 :: ErrorCode) nullPtr (c_ld_client_get_loggroup_by_id client' logid)
   case errno of
     C_OK       -> return True

--- a/hstream-store/HStream/Store/Internal/Types.hsc
+++ b/hstream-store/HStream/Store/Internal/Types.hsc
@@ -320,6 +320,20 @@ peekLogTailAttrsCbData ptr = do
   tail_attributes_ptr <- (#peek log_tail_attributes_cb_data_t, tail_attributes) ptr
   return $ LogTailAttrsCbData retcode tail_attributes_ptr
 
+data IsLogEmptyCbData = IsLogEmptyCbData
+  { isLogEmptyCbRetCode :: !ErrorCode
+  , isLogEmptyCbAttrPtr :: !CBool
+  }
+
+isLogEmptyCbDataSize :: Int
+isLogEmptyCbDataSize = (#size is_log_empty_cb_data_t)
+
+peekIsLogEmptyCbData :: Ptr IsLogEmptyCbData -> IO IsLogEmptyCbData
+peekIsLogEmptyCbData ptr = do
+  retcode <- (#peek is_log_empty_cb_data_t, st) ptr
+  empty <- (#peek is_log_empty_cb_data_t, empty) ptr
+  return $ IsLogEmptyCbData retcode empty
+
 -------------------------------------------------------------------------------
 
 data LogDeviceClient

--- a/hstream-store/admin/HStream/Store/Admin/Command/Logs.hs
+++ b/hstream-store/admin/HStream/Store/Admin/Command/Logs.hs
@@ -36,7 +36,7 @@ runLogsInfo :: HeaderConfig AdminAPI -> S.C_LogID -> IO ()
 runLogsInfo conf logid = do
   let client' = buildLDClientRes conf Map.empty
   withResource client' $ \client -> do
-    isExist <- S.doesLogIdHasGroup client logid
+    isExist <- S.logIdHasGroup client logid
     if isExist then info client
                else putStrLn "No log-group has this ID!"
   where
@@ -62,6 +62,8 @@ runLogsInfo conf logid = do
       head_time_stamp <- S.getLogHeadAttrsTrimPointTimestamp head_attr
       putStrLn $ "  Approximate timestamp of trim point (ms): "
         ++ prettyPrintTimeStamp head_time_stamp
+      empty <- S.isLogEmpty client logid
+      putStrLn $ "Log Empty?: " <> show empty
 
     prettyPrintLSN lsn =
       "e" ++ show (lsn `shiftR` 32) ++ "n" ++ show (lsn .&. 0xFFFFFFFF)

--- a/hstream-store/cbits/hs_logdevice.cpp
+++ b/hstream-store/cbits/hs_logdevice.cpp
@@ -75,6 +75,20 @@ c_lsn_t ld_client_get_tail_lsn_sync(logdevice_client_t* client,
   return client->rep->getTailLSNSync(facebook::logdevice::logid_t(logid));
 }
 
+HsInt ld_client_is_log_empty(logdevice_client_t* client, c_logid_t logid,
+                             HsStablePtr mvar, HsInt cap,
+                             is_log_empty_cb_data_t* data) {
+  auto cb = [data, cap, mvar](facebook::logdevice::Status st,
+                              bool empty) {
+    if (data) {
+      data->st = static_cast<c_error_code_t>(st);
+      data->empty = empty;
+    }
+    hs_try_putmvar(cap, mvar);
+  };
+  return client->rep->isLogEmpty(logid_t(logid), cb);
+}
+
 HsInt ld_client_get_tail_lsn(logdevice_client_t* client, c_logid_t logid,
                              HsStablePtr mvar, HsInt cap,
                              c_error_code_t* st_out, c_lsn_t* lsn_out) {

--- a/hstream-store/include/hs_logdevice.h
+++ b/hstream-store/include/hs_logdevice.h
@@ -330,6 +330,12 @@ typedef struct log_tail_attributes_cb_data_t {
   c_error_code_t st;
   logdevice_log_tail_attributes_t* tail_attributes;
 } log_tail_attributes_cb_data_t;
+
+typedef struct is_log_empty_cb_data_t {
+  c_error_code_t st;
+  bool empty;
+} is_log_empty_cb_data_t;
+
 // ----------------------------------------------------------------------------
 // Client
 
@@ -339,6 +345,10 @@ new_logdevice_client(char* config_path, logdevice_client_t** client_ret);
 void free_logdevice_client(logdevice_client_t* client);
 
 size_t ld_client_get_max_payload_size(logdevice_client_t* client);
+
+HsInt ld_client_is_log_empty(logdevice_client_t* client, c_logid_t logid,
+                             HsStablePtr mvar, HsInt cap,
+                             is_log_empty_cb_data_t* data);
 
 c_lsn_t ld_client_get_tail_lsn_sync(logdevice_client_t* client, uint64_t logid);
 


### PR DESCRIPTION
## Description

Added hstore api `isLogEmpty` and prints the information when `logs info` is called
Fixes #289 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
