### PR TITLE
hstream-server: support HStreamRecord format

### DIFF
--- a/hstream-store/HStream/Store/Internal/Types.hsc
+++ b/hstream-store/HStream/Store/Internal/Types.hsc
@@ -15,6 +15,7 @@ import           Foreign.ForeignPtr
 import           Foreign.Marshal.Alloc
 import           Foreign.Ptr
 import           Foreign.Storable
+import qualified Text.Read             as Read
 import           Z.Data.CBytes         (CBytes)
 import qualified Z.Data.CBytes         as CBytes
 import           Z.Data.Vector         (Bytes)
@@ -387,6 +388,16 @@ data Compression
   | CompressionLZ4
   | CompressionLZ4HC
   deriving (Eq, Ord, Show)
+
+-- TODO: Doesn't support `CompressionZSTD Int` now
+instance Read Compression where
+  readPrec = do
+    i <- Read.lexP
+    case i of
+      Read.Ident "none"        -> return CompressionNone
+      Read.Ident "lz4"         -> return CompressionLZ4
+      Read.Ident "lz4hc"       -> return CompressionLZ4HC
+      x -> errorWithoutStackTrace $ "cannot parse value: " <> show x
 
 fromCompression :: Compression -> C_Compression
 fromCompression CompressionNone = ((#const static_cast<HsInt>(Compression::NONE)), 0)

--- a/hstream/common/hstream-common.cabal
+++ b/hstream/common/hstream-common.cabal
@@ -29,6 +29,7 @@ library
     HStream.Utils
     HStream.Utils.Converter
     HStream.Utils.Format
+    HStream.Utils.BuildRecord
     ThirdParty.Google.Protobuf.Struct
     ThirdParty.Google.Protobuf.Timestamp
 

--- a/hstream/common/src/HStream/Utils.hs
+++ b/hstream/common/src/HStream/Utils.hs
@@ -3,22 +3,27 @@
 module HStream.Utils
   ( module HStream.Utils.Converter
   , module HStream.Utils.Format
+  , module HStream.Utils.BuildRecord
   , getKeyWordFromException
   , flattenJSON
+  , getProtoTimestamp
   ) where
 
-import           Control.Exception                 (Exception (..))
-import qualified Data.Text.Lazy                    as TL
+import           Control.Exception                    (Exception (..))
+import           Control.Monad                        (join)
+import           Data.Aeson                           as Aeson
+import           Data.Bifunctor                       (first)
+import qualified Data.HashMap.Strict                  as HM
+import           Data.Text                            (Text)
+import qualified Data.Text                            as Text
+import qualified Data.Text.Lazy                       as TL
+import           Z.IO.Time                            (SystemTime (..),
+                                                       getSystemTime')
 
-import           Control.Monad                     (join)
-import           Data.Aeson                        as Aeson
-import           Data.Bifunctor                    (first)
-import qualified Data.HashMap.Strict               as HM
-import           Data.Text                         (Text)
-import qualified Data.Text                         as Text
+import           HStream.Utils.BuildRecord
 import           HStream.Utils.Converter
 import           HStream.Utils.Format
-import           ThirdParty.Google.Protobuf.Struct
+import           ThirdParty.Google.Protobuf.Timestamp
 
 getKeyWordFromException :: Exception a => a -> TL.Text
 getKeyWordFromException =  TL.pack . takeWhile (/='{') . show
@@ -38,3 +43,8 @@ flattenJSON' splitor prefix (k, v) = do
   case v of
     Aeson.Object o -> join $ map (flattenJSON' splitor (prefix <> splitor <> k)) (HM.toList o)
     _              -> [(prefix <> splitor <> k, v)]
+
+getProtoTimestamp :: IO Timestamp
+getProtoTimestamp = do
+  MkSystemTime sec nano <- getSystemTime'
+  return $ Timestamp sec (fromIntegral nano)

--- a/hstream/common/src/HStream/Utils/BuildRecord.hs
+++ b/hstream/common/src/HStream/Utils/BuildRecord.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TypeApplications #-}
+
+module HStream.Utils.BuildRecord where
+
+import           Data.Aeson
+import           Data.Bits                            (shiftL)
+import           Data.ByteString.Lazy                 (ByteString)
+import qualified Data.ByteString.Lazy                 as BL
+import           Data.Int                             (Int64)
+import           Data.Map.Strict                      (Map)
+import           Data.Maybe                           (fromJust)
+import           Data.Text.Lazy                       (Text)
+import           Data.Word                            (Word32)
+import           Z.Data.Vector                        (Bytes)
+import           Z.Foreign                            (fromByteString,
+                                                       toByteString)
+
+import           HStream.Server.HStreamApi
+import           ThirdParty.Google.Protobuf.Timestamp
+
+jsonPayloadFlag :: Word32
+jsonPayloadFlag = shiftL 0x01 24
+
+rawPayloadFlag :: Word32
+rawPayloadFlag = shiftL 0x02 24
+
+buildRecordHeader :: Word32 -> Map Text Text -> Timestamp -> Text -> HStreamRecordHeader
+buildRecordHeader flag mp timestamp key =
+  HStreamRecordHeader
+    { hstreamRecordHeaderFlag = flag
+    , hstreamRecordHeaderAttributes = mp
+    , hstreamRecordHeaderPublishTime = Just timestamp
+    , hstreamRecordHeaderKey = key
+    }
+
+buildRecord :: HStreamRecordHeader -> ByteString -> HStreamRecord
+buildRecord header payload = HStreamRecord (Just header) (BL.toStrict payload)
+
+encodeRecord :: HStreamRecord -> Bytes
+encodeRecord = fromByteString . BL.toStrict . encode
+
+decodeRecord :: Bytes -> HStreamRecord
+decodeRecord record =
+  let rc = decode . BL.fromStrict . toByteString $ record
+  in case rc of
+      Nothing  -> error $ "Decode HStreamRecord error!"
+      Just res -> res
+
+getPayload :: HStreamRecord -> Bytes
+getPayload HStreamRecord{..} = fromByteString hstreamRecordPayload
+
+getPayloadFlag :: HStreamRecord -> Word32
+getPayloadFlag = hstreamRecordHeaderFlag . fromJust . hstreamRecordHeader
+
+getTimeStamp :: HStreamRecord -> Int64
+getTimeStamp HStreamRecord{..} =
+  let Timestamp{..} = fromJust . hstreamRecordHeaderPublishTime . fromJust $ hstreamRecordHeader
+      !ts = floor @Double $ (fromIntegral timestampSeconds * 1e3) + (fromIntegral timestampNanos / 1e6)
+  in ts

--- a/hstream/test/HStream/RunSQLSpec.hs
+++ b/hstream/test/HStream/RunSQLSpec.hs
@@ -245,6 +245,7 @@ fetchClickHouse :: Text -> IO (V.Vector (V.Vector ClickHouse.ClickhouseType))
 fetchClickHouse source = do
   conn <- ClickHouse.createClient clickHouseConnectInfo
   q <- ClickHouse.query conn $ "SELECT * FROM " <> Text.unpack source <> " ORDER BY temperature"
+  _ <- ClickHouse.query conn $ "DROP TABLE IF EXISTS " <> Text.unpack source
   ClickHouse.closeClient conn
   case q of
     Right res -> return res


### PR DESCRIPTION
# Pull Request Template

## Description

Update `executeQueryHandler` to support `HStreamRecord` format.

Add an extra `InsertType` field to `InsertPlan` constructor, so that we can use it to distinguish the specific storage format when we need to construct `HStreamRecord`. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
