### PR TITLE
hstream-server: implement listSubscriptions and deleteSubcribe grpc

### DIFF
--- a/hstream/common/proto/HStream/Server/HStreamApi.proto
+++ b/hstream/common/proto/HStream/Server/HStreamApi.proto
@@ -23,6 +23,10 @@ service HStreamApi {
 
   rpc Subscribe(Subscription) returns (Subscription) {}
 
+  rpc DeleteSubscription(DeleteSubscriptionRequest) returns (google.protobuf.Empty) {}
+
+  rpc ListSubscriptions(google.protobuf.Empty) returns (ListSubscriptionsResponse) {}
+
   rpc Fetch(FetchRequest) returns (FetchResponse) {}
 
   rpc CommitOffset(CommittedOffset) returns (CommittedOffset) {}
@@ -139,6 +143,10 @@ message SubscriptionOffset {
   }
 }
 
+message DeleteSubscriptionRequest {
+  string subscriptionId = 1;
+}
+
 message FetchRequest {
   string subscriptionId = 1;
   uint64 timeout = 2;
@@ -171,6 +179,10 @@ message DeleteStreamRequest {
 
 message ListStreamsResponse {
   repeated Stream streams = 1;
+}
+
+message ListSubscriptionsResponse {
+  repeated Subscription subscription = 1;
 }
 
 message Stream {


### PR DESCRIPTION
## Description

Implement `listSubscriptions` and `deleteSubscribe` grpc

Ensure that the `subscriptionId` and `reader` correspond to each other.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
