### PR TITLE
fix quote related misuses in cli

### DIFF
--- a/hstream-sql/etc/SQL.cf
+++ b/hstream-sql/etc/SQL.cf
@@ -21,15 +21,17 @@ INSERT INTO demoStream (temperature, humidity) VALUES (30, 75);
 
 --------------------------------------------------------------------------------
 
-PInteger.  PNInteger ::= "+" Integer ;
-IPInteger. PNInteger ::=     Integer ;
-NInteger.  PNInteger ::= "-" Integer ;
+PInteger.  PNInteger ::= "+" IntegerNew ;
+IPInteger. PNInteger ::=     IntegerNew ;
+NInteger.  PNInteger ::= "-" IntegerNew ;
 
 PDouble.  PNDouble ::= "+" Double ;
 IPDouble. PNDouble ::=     Double ;
 NDouble.  PNDouble ::= "-" Double ;
 
 token SString '\'' char+ '\'' ;
+token IntegerNew digit+ ;
+token ID digit (["abcdef"]|digit|'_'|'-')+ ;
 --------------------------------------------------------------------------------
 
 comment "//" ;
@@ -40,6 +42,7 @@ entrypoints SQL ;
 QSelect.     SQL ::= Select     ";" ;
 QSelectView. SQL ::= SelectView ";" ;
 QCreate.     SQL ::= Create     ";" ;
+
 QInsert.     SQL ::= Insert     ";" ;
 QShow.       SQL ::= ShowQ      ";" ;
 QDrop.       SQL ::= Drop       ";" ;
@@ -88,7 +91,8 @@ DropStream. DropOption ::= "STREAM";
 DropView. DropOption ::= "VIEW";
 
 -- Terminate Query
-TerminateQuery. Terminate ::= "TERMINATE" "QUERY" String ;
+TerminateQueryID. Terminate ::= "TERMINATE" "QUERY" ID ;
+TerminateQueryIdent. Terminate ::= "TERMINATE" "QUERY" Ident ;
 TerminateAll. Terminate ::= "TERMINATE" "ALL";
 
 ---- SelectView Query

--- a/hstream-sql/src/HStream/SQL/AST.hs
+++ b/hstream-sql/src/HStream/SQL/AST.hs
@@ -468,12 +468,13 @@ type instance RefinedType DropOption = RDropOption
 
 ---- Terminate
 data RTerminate
-  = RTerminateQuery String
+  = RTerminateQuery Text
   | RTerminateAll
   deriving (Eq, Show)
 instance Refine Terminate where
-  refine (TerminateQuery _ x) = RTerminateQuery x
-  refine (TerminateAll   _  ) = RTerminateAll
+  refine (TerminateQueryID _ (ID x))       = RTerminateQuery x
+  refine (TerminateQueryIdent _ (Ident x)) = RTerminateQuery x
+  refine (TerminateAll   _  )              = RTerminateAll
 type instance RefinedType Terminate = RTerminate
 
 ---- SQL

--- a/hstream-sql/src/HStream/SQL/Codegen.hs
+++ b/hstream-sql/src/HStream/SQL/Codegen.hs
@@ -132,7 +132,7 @@ streamCodegen input = do
     RQDrop (RDrop RDropView x)         -> return $ DropPlan False (DView x)
     RQDrop (RDropIf RDropStream x)     -> return $ DropPlan True (DStream x)
     RQDrop (RDropIf RDropView x)       -> return $ DropPlan True (DView x)
-    RQTerminate (RTerminateQuery qid)  -> return $ TerminatePlan (OneQuery $ CB.pack qid)
+    RQTerminate (RTerminateQuery qid)  -> return $ TerminatePlan (OneQuery . CB.pack . T.unpack $ qid)
     RQTerminate RTerminateAll          -> return $ TerminatePlan AllQuery
     RQSelectView rSelectView           -> return $ SelectViewPlan rSelectView
 

--- a/hstream-sql/src/HStream/SQL/Extra.hs
+++ b/hstream-sql/src/HStream/SQL/Extra.hs
@@ -11,15 +11,15 @@ module HStream.SQL.Extra
 
 import           Data.Char         (isSpace)
 import qualified Data.List         as L
-import           Data.Text         (Text)
+import           Data.Text         (Text, unpack)
 import           HStream.SQL.Abs
 import           HStream.SQL.Print (Print, printTree)
 
 --------------------------------------------------------------------------------
 extractPNInteger :: PNInteger -> Integer
-extractPNInteger (PInteger  _ n) = n
-extractPNInteger (IPInteger _ n) = n
-extractPNInteger (NInteger  _ n) = (-n)
+extractPNInteger (PInteger  _ (IntegerNew n)) = read $ unpack n
+extractPNInteger (IPInteger _ (IntegerNew n)) = read $ unpack n
+extractPNInteger (NInteger  _ (IntegerNew n)) = - (read . unpack $ n)
 
 extractPNDouble :: PNDouble -> Double
 extractPNDouble (PDouble  _ n) = n

--- a/hstream/common/src/HStream/Utils/Format.hs
+++ b/hstream/common/src/HStream/Utils/Format.hs
@@ -85,7 +85,7 @@ formatValue (P.Value (Just x)) = formatValueKind x
 formatValueKind :: P.ValueKind -> String
 formatValueKind (P.ValueKindNullValue _)   = "NULL"
 formatValueKind (P.ValueKindNumberValue n) = show n
-formatValueKind (P.ValueKindStringValue s) = show s
+formatValueKind (P.ValueKindStringValue s) = TL.unpack s
 formatValueKind (P.ValueKindBoolValue   b) = show b
 formatValueKind (P.ValueKindStructValue s) = formatStruct s
 formatValueKind (P.ValueKindListValue (P.ListValue vs)) = unwords . map formatValue . V.toList $ vs


### PR DESCRIPTION
Now `SHOW` won't print out `"` `"`. 
Terminate Query No longer requires `"` around id.