### PR TITLE
hstream-server: refactor handlers to support resubscribe subscription with same subscriptionId

### DIFF
--- a/common/proto/HStream/Server/HStreamApi.proto
+++ b/common/proto/HStream/Server/HStreamApi.proto
@@ -19,6 +19,8 @@ service HStreamApi {
   // e.g., insert, create, show/list, select(without emit changes) ...
   rpc ExecuteQuery(CommandQuery) returns (CommandQueryResponse);
 
+  rpc sendConsumerHeartbeat(ConsumerHeartbeatRequest) returns (ConsumerHeartbeatResponse) {}
+
   rpc Append(AppendRequest) returns (AppendResponse) {}
 
   rpc Subscribe(Subscription) returns (Subscription) {}
@@ -114,6 +116,14 @@ enum HStreamServerError {
   NoError = 0;
   UnknownError = 1;
   NotExistError = 3;
+}
+
+message ConsumerHeartbeatRequest {
+  string subscriptionId = 1;
+}
+
+message ConsumerHeartbeatResponse {
+  string subscriptionId = 1;
 }
 
 message AppendRequest {

--- a/hstream/hstream.cabal
+++ b/hstream/hstream.cabal
@@ -66,6 +66,9 @@ library
     , Z-Data
     , Z-IO
     , zoovisitor
+    , stm
+    , timers
+    , suspend
 
   default-language: Haskell2010
   ghc-options:
@@ -93,6 +96,9 @@ executable hstream-server
     , Z-Data
     , Z-IO
     , zoovisitor
+    , stm
+    , timers
+    , suspend
 
   default-language: Haskell2010
   ghc-options:


### PR DESCRIPTION
## Description

Add a `sendConsumerHeartbeat` rpc to let a client send a heartbeat to server. When server receives the rpc, it will update the set of subscribed subscriptionId, release unused subscriptionId so that other client can subscribe it using the same id.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
