### PR TITLE
hstream-server: fix send heartbeat after deleteSubscription return success

### DIFF
--- a/hstream/src/HStream/Server/Handler.hs
+++ b/hstream/src/HStream/Server/Handler.hs
@@ -384,9 +384,9 @@ consumerHeartbeatHandler
 consumerHeartbeatHandler ServerContext{..} (ServerNormalRequest _metadata ConsumerHeartbeatRequest{..}) = do
   timestamp <- getCurrentTimestamp
   atomically $ do
-    hm <- readTVar subscribedReaders
-    case HM.lookup consumerHeartbeatRequestSubscriptionId hm of
-      Nothing -> returnErrResp StatusInternal "SubscriptionId doesn't exist."
+    hm <- readTVar subscribeHeap
+    case Map.lookup consumerHeartbeatRequestSubscriptionId hm of
+      Nothing -> returnErrResp StatusInternal "Cann't send hearbeat to an unsubscribed stream."
       Just _  -> do
         modifyTVar' subscribeHeap $ \hp ->
           Map.insert consumerHeartbeatRequestSubscriptionId timestamp hp


### PR DESCRIPTION
# Pull Request Template

## Description

Bugfix: after `deleteSubscription`, send heartbeat should return an error, but currently return success.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit test

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
