### PR TITLE
hstore: add benchmark on appendBatch

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -68,6 +68,8 @@ cradle:
       component: "hstream-store:exe:hstore-bench-writter"
     - path: "hstream-store/bench"
       component: "hstream-store:bench:hstore-bench-append"
+    - path: "hstream-store/bench"
+      component: "hstream-store:bench:hstore-bench-append-batch"
 
     - path: "hstream-store/admin"
       component: "lib:hstore-admin"

--- a/hstream-store/bench/AppendBatchBench.hs
+++ b/hstream-store/bench/AppendBatchBench.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Main where
+
+import           Control.Monad          (void)
+import qualified Criterion.Main         as C
+import qualified Criterion.Main.Options as C
+import qualified Data.ByteString        as B
+import qualified Options.Applicative    as O
+import           Z.Data.CBytes          (CBytes)
+import           Z.Data.Vector          (Bytes)
+import qualified Z.Data.Vector          as V
+
+import qualified Data.ByteUnits         as BU
+import qualified HStream.Store          as S
+import qualified HStream.Store.Logger   as S
+
+-- | To run the benchmark:
+--
+-- > cabal run -- hstore-bench-append-batch --config /data/store/logdevice.conf --logid 1 --output bench.html --regress allocated:iters +RTS -T
+main :: IO ()
+main = do
+  AppendBatchBenchOpts{..} <- O.execParser $ C.describeWith appendBenchParser
+  _ <- S.setLogDeviceDbgLevel S.C_DBG_ERROR
+  client <- S.newLDClient configFile
+  runAppendBatchBench mode client logid
+
+data AppendBatchBenchOpts = AppendBatchBenchOpts
+  { configFile :: CBytes
+  , logid      :: S.C_LogID
+  , mode       :: C.Mode
+  }
+
+appendBenchParser :: O.Parser AppendBatchBenchOpts
+appendBenchParser = AppendBatchBenchOpts
+  <$> O.strOption ( O.long "config"
+               <> O.metavar "STRING"
+               <> O.help "path to the client config file")
+  <*> O.option O.auto ( O.long "logid"
+                     <> O.metavar "INT"
+                     <> O.help "the logid to append to")
+  <*> C.parseWith C.defaultConfig
+
+runAppendBatchBench :: C.Mode -> S.LDClient -> S.C_LogID -> IO ()
+runAppendBatchBench mode client logid = do
+  C.runMode mode
+    [ let (size, num) = (1024, 100)
+      in C.bgroup (message size num) $ benches size num
+    , let (size, num) = (1024, 1000)
+      in C.bgroup (message size num) $ benches size num
+    , let (size, num) = (1024 * 1024, 100)
+      in C.bgroup (message size num) $ benches size num
+    ]
+    where
+      bytesInBatch :: [Bytes] -> IO ()
+      bytesInBatch bytes = void $ S.appendBatch client logid bytes S.CompressionLZ4 Nothing
+
+      byteStringInBatch :: [B.ByteString] -> IO ()
+      byteStringInBatch bs = void $ S.appendBatchBS client logid bs S.CompressionLZ4 Nothing
+
+      message :: Int -> Int -> String
+      message size num = "append " <> show num <> " * size " <> prettySize size <> " messages in batch"
+
+      prettySize :: Int -> String
+      prettySize size = BU.getShortHand (BU.getAppropriateUnits (BU.ByteValue (fromIntegral size) BU.Bytes))
+
+      benches :: Int -> Int -> [C.Benchmark]
+      benches size num =
+        let !bytes = V.replicate size 97
+            !bs    = B.replicate size 97
+            !bytesBatch = replicate num bytes
+            !bsBatch    = replicate num bs
+        in
+          [ C.bench "append bytes in batch" $ C.nfIO (bytesInBatch bytesBatch)
+          , C.bench "append bytestring in batch" $ C.nfIO (byteStringInBatch bsBatch)
+          ]

--- a/hstream-store/hstream-store.cabal
+++ b/hstream-store/hstream-store.cabal
@@ -159,6 +159,41 @@ benchmark hstore-bench-append
   build-depends:
     , base                  >=4.11 && <5
     , bytestring            ^>=0.10
+    , byteunits             ^>=0.4
+    , criterion             ^>=1.5
+    , hstream-store
+    , optparse-applicative  ^>=0.16
+    , Z-Data
+    , Z-IO
+
+  default-extensions:
+    DeriveGeneric
+    DerivingStrategies
+    EmptyDataDeriving
+    GADTSyntax
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    OverloadedStrings
+    RecordWildCards
+    ScopedTypeVariables
+    TypeApplications
+    UnliftedFFITypes
+
+  default-language:   Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -threaded -rtsopts -with-rtsopts=-N
+
+benchmark hstore-bench-append-batch
+  type:               exitcode-stdio-1.0
+  main-is:            AppendBatchBench.hs
+
+  hs-source-dirs:     bench
+  build-depends:
+    , base                  >=4.11 && <5
+    , bytestring            ^>=0.10
+    , byteunits             ^>=0.4
     , criterion             ^>=1.5
     , hstream-store
     , optparse-applicative  ^>=0.16


### PR DESCRIPTION
| Table      | Time | Space |
| ----------- | ----------- | ----------|
| 100 * 1KB Bytes       |  286 μs      | 24KB |
| 100 * 1KB BS           | 301 μs       | 20KB  |
| 1000 * 1KB Bytes       |  932 μs      | 240KB |
| 1000 * 1KB BS           | 946 μs       | 200KB  |
| 100 * 1MB Bytes       |  42 ms      | 24KB |
| 100 * 1MB BS           | 38 ms       | 20KB  |