### PR TITLE
sql: fix pattern matching coverage on `RawColumn`

### DIFF
--- a/hstream-sql/src/HStream/SQL/AST.hs
+++ b/hstream-sql/src/HStream/SQL/AST.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 module HStream.SQL.AST where
@@ -391,7 +389,8 @@ instance Refine SelectView where
       svSel = case sel of
         (DSel _ (SelListAsterisk _)) -> SVSelectAll
         (DSel _ (SelListSublist _ dcols)) ->
-          let (f :: DerivedCol -> (FieldName, FieldAlias)) = \case
+          let f :: DerivedCol -> (FieldName, FieldAlias)
+              f docl = case docl of
                 (DerivedColSimpl _ expr@(ExprColName _ (ColNameSimple _ (Ident col))))       ->
                   (col, trimSpacesPrint expr)
                 (DerivedColSimpl _ expr@(ExprRaw _ (RawColumn col)))                         ->

--- a/hstream-sql/src/HStream/SQL/AST.hs
+++ b/hstream-sql/src/HStream/SQL/AST.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module HStream.SQL.AST where
 


### PR DESCRIPTION
namely we can `parseAndRefine` the following now:
```haskell
parseAndRefine "SELECT `SUM(a)` FROM my_view WHERE b = 1;"
```
