### PR TITLE
ci: preventing a specific failing matrix job from failing a workflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     name: GHC-${{ matrix.ghc }}
     strategy:
+      fail-fast: false
       matrix:
         ghc: ${{ fromJson(needs.pre-build.outputs.ghc) }}
     steps:


### PR DESCRIPTION
For now, if 8.8.4 job failed, 8.10.4 will be canceled.