### PR TITLE
feat: use https as submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/gRPC-haskell"]
 	path = external/gRPC-haskell
-	url = git@github.com:hstreamdb/gRPC-haskell.git
+	url = https://github.com/hstreamdb/gRPC-haskell.git
 [submodule "external/hsthrift"]
 	path = external/hsthrift
-	url = git@github.com:hstreamdb/hsthrift.git
+	url = https://github.com/hstreamdb/hsthrift.git


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

# Pull Request Template

## Description

Not everyone has SSH key added to their local machine. For most cases, developers simply run `git clone` with only HTTPS credentials or no credentials. Therefore, this PR changes submodule to HTTPS upstream instead of the SSH ones.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

```
~/Work/hstream/external/gRPC-haskell
$ git remote get-url origin
https://github.com/hstreamdb/gRPC-haskell.git
```

## Checklist:

### Must:
- [x] I have run `format.sh` under `script`
- [x] I have performed a self-**review** of my own code
- [x] I have **comment**ed my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

### Semi-Must
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any **misspellings**

### Optional:
- [x] My code follows the [**style guidelines**](https://docs.hstream.io/development/haskell-style/) of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
