### PR TITLE
add round robin strategy for load balancer

### DIFF
--- a/common/HStream/Utils.hs
+++ b/common/HStream/Utils.hs
@@ -10,6 +10,7 @@ module HStream.Utils
   , flattenJSON
   , genUnique
   , setupSigsegvHandler
+  , ifM
   ) where
 
 import           Control.Exception          (Exception (..))
@@ -76,3 +77,7 @@ genUnique = do
 
 foreign import ccall unsafe "hs_common.h setup_sigsegv_handler"
   setupSigsegvHandler :: IO ()
+
+ifM :: Bool -> m a -> m a -> m a
+ifM True x _  = x
+ifM False _ y = y

--- a/common/proto/HStream/Server/HStreamInternal.proto
+++ b/common/proto/HStream/Server/HStreamInternal.proto
@@ -14,13 +14,9 @@ service HStreamInternal {
   rpc RestartConnector(CreateSinkConnectorRequest) returns (Connector) {}
   rpc TerminateConnector(TerminateConnectorRequest) returns (google.protobuf.Empty) {}
 
-  rpc GetNodesRanking(google.protobuf.Empty) returns (GetNodesRankingResponse) {}
+  rpc GetAllocatedNode(google.protobuf.Empty) returns (ServerNode) {}
   rpc TakeSubscription(TakeSubscriptionRequest) returns (google.protobuf.Empty) {}
   rpc TakeStream(TakeStreamRequest) returns (google.protobuf.Empty) {}
-}
-
-message GetNodesRankingResponse {
-  repeated ServerNode nodes = 1;
 }
 
 message TakeSubscriptionRequest {

--- a/hstream/app/server.hs
+++ b/hstream/app/server.hs
@@ -24,7 +24,8 @@ import           HStream.Server.Leader          (selectLeader)
 import           HStream.Server.LoadBalance     (startWritingLoadReport)
 import           HStream.Server.Persistence     (defaultHandle,
                                                  initializeAncestors)
-import           HStream.Server.Types           (LoadManager,
+import           HStream.Server.Types           (LoadBalanceMode (..),
+                                                 LoadManager,
                                                  ServerContext (..),
                                                  ServerOpts (..))
 import           HStream.Store                  (Compression (..))
@@ -117,6 +118,10 @@ parseConfig =
                    <> showDefault <> value (Log.LDLogLevel Log.C_DBG_INFO)
                    <> help "hstore log level"
                     )
+    <*> option auto ( long "load-balance-mode" <> metavar "[round-robin|hardware-usage]"
+                   <> showDefault <> value RoundRobin
+                   <> help "hserver cluster load balance mode"
+                    )
 
 app :: ServerOpts -> IO ()
 app config@ServerOpts{..} = do
@@ -131,7 +136,7 @@ serve :: ServiceOptions -> ServiceOptions -> ServerContext -> LoadManager -> IO 
 serve options@ServiceOptions{..} optionsInternal sc@ServerContext{..} lm = do
   startWritingLoadReport zkHandle lm
 
-  selectLeader sc lm
+  selectLeader sc
 
   -- GRPC service
   Log.i "************************"

--- a/hstream/hstream.cabal
+++ b/hstream/hstream.cabal
@@ -54,6 +54,7 @@ library
     HStream.Server.Handler.Subscription
     HStream.Server.Handler.View
     HStream.Server.Persistence.Common
+    HStream.Server.Persistence.ClusterConfig
     HStream.Server.Persistence.MemoryStore
     HStream.Server.Persistence.Nodes
     HStream.Server.Persistence.Object

--- a/hstream/src/HStream/Server/Bootstrap.hs
+++ b/hstream/src/HStream/Server/Bootstrap.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -10,18 +9,20 @@ module HStream.Server.Bootstrap
   ( startServer
   ) where
 
-import qualified Data.Text                     as T
+import qualified Data.Text                                as T
 import           ZooKeeper.Types
 
 
-import           HStream.Server.Initialization (initNodePath)
+import           HStream.Server.Initialization            (initNodePath)
 import           HStream.Server.Persistence
-import           HStream.Server.Types          (ServerOpts (..))
+import           HStream.Server.Persistence.ClusterConfig (checkConfigConsistent)
+import           HStream.Server.Types                     (ServerOpts (..))
 
 --------------------------------------------------------------------------------
 
 startServer :: ZHandle -> ServerOpts -> IO () -> IO ()
-startServer zk ServerOpts {..} myApp = do
+startServer zk opts@ServerOpts {..} myApp = do
   initNodePath zk _serverID (T.pack _serverAddress) (fromIntegral _serverPort) (fromIntegral _serverInternalPort)
+  checkConfigConsistent opts zk
   setNodeStatus zk _serverID Working
   myApp

--- a/hstream/src/HStream/Server/Handler/Subscription.hs
+++ b/hstream/src/HStream/Server/Handler/Subscription.hs
@@ -47,7 +47,6 @@ import           HStream.Server.HStreamApi
 import           HStream.Server.Handler.Common    (getStartRecordId,
                                                    getSuccessor,
                                                    insertAckedRecordId)
-import           HStream.Server.LoadBalance       (getNodesRanking)
 import           HStream.Server.Persistence       (ObjRepType (..))
 import qualified HStream.Server.Persistence       as P
 import           HStream.Server.Types
@@ -202,20 +201,17 @@ streamingFetchHandler ctx@ServerContext {..} (ServerBiDiRequest _ streamRecv str
                       | otherwise -> return $
                           ServerBiDiResponse [] StatusInternal "The subscription is bound to another node. Call `lookupSubscription` to get the right one"
                     Nothing -> do
+                      -- TODO: Assign the subscription to the node allocated
+                      -- nodeID <- serverNodeId <$> getAllocatedNode ctx
                       Log.debug $ Log.buildText streamingFetchRequestSubscriptionId <> " need to assign to a server node."
-                      nodeIDs <- getNodesRanking ctx <&> fmap serverNodeId
-                      if serverID `L.elem` nodeIDs
-                        then do
-                          let subCtx = SubscriptionContext { _subctxNode = serverID }
-                          modifyMVar_ subscriptionCtx
-                            (\ctxs -> do
-                                newCtxMVar <- newMVar subCtx
-                                return $ Map.insert (T.unpack streamingFetchRequestSubscriptionId) newCtxMVar ctxs
-                            )
-                          P.storeObject streamingFetchRequestSubscriptionId subCtx zkHandle -- sync subctx to zk
-                          doFirstFetchCheck streamingFetchReq
-                        else do
-                          return $ ServerBiDiResponse [] StatusInternal "There is no available node for allocating the subscription"
+                      let subCtx = SubscriptionContext { _subctxNode = serverID }
+                      modifyMVar_ subscriptionCtx
+                        (\ctxs -> do
+                            newCtxMVar <- newMVar subCtx
+                            return $ Map.insert (T.unpack streamingFetchRequestSubscriptionId) newCtxMVar ctxs
+                        )
+                      P.storeObject streamingFetchRequestSubscriptionId subCtx zkHandle -- sync subctx to zk
+                      doFirstFetchCheck streamingFetchReq
                 False ->
                   return $ ServerBiDiResponse [] StatusInternal "Subscription does not exist"
           | otherwise -> do

--- a/hstream/src/HStream/Server/Initialization.hs
+++ b/hstream/src/HStream/Server/Initialization.hs
@@ -82,7 +82,11 @@ initializeServer ServerOpts{..} zk = do
 
   lastSysResUsage <- initLastSysResUsage
   currentLoadReport <- initLoadReport lastSysResUsage
-  currentLoadReports <- newMVar HM.empty
+  currentLoadReportZK <- newMVar LoadReport {
+      systemResourceUsage = SystemResourcePercentageUsage 0 0 0 0
+    , isUnderloaded       = True
+    , isOverloaded        = False
+    }
 
   currentLeader <- newEmptyMVar
 
@@ -117,7 +121,7 @@ initializeServer ServerOpts{..} zk = do
       sID             = _serverID
     , loadReport      = currentLoadReport
     , lastSysResUsage = lastSysResUsage
-    , loadReports     = currentLoadReports
+    , loadReportZK    = currentLoadReportZK
     })
 
 --------------------------------------------------------------------------------

--- a/hstream/src/HStream/Server/Persistence/ClusterConfig.hs
+++ b/hstream/src/HStream/Server/Persistence/ClusterConfig.hs
@@ -1,0 +1,53 @@
+module HStream.Server.Persistence.ClusterConfig where
+
+import           Control.Exception
+import           Control.Monad              (void, when)
+import           Z.Data.CBytes              (CBytes)
+import qualified Z.Data.CBytes              as CB
+import           ZooKeeper                  (zooCreate, zooGetChildren)
+import           ZooKeeper.Types
+
+import qualified HStream.Logger             as Log
+import           HStream.Server.Persistence
+import           HStream.Server.Types       (ClusterConfig (..),
+                                             LoadBalanceMode, ServerOpts (..))
+import           HStream.Utils              (valueToBytes)
+
+checkConfigConsistent :: ServerOpts -> ZHandle -> IO ()
+checkConfigConsistent opts@ServerOpts {..} zk = do
+  nodes <- unStrVec . strsCompletionValues <$> zooGetChildren zk configPath
+  let serverConfig = ClusterConfig {loadBalanceMode = _loadBalanceMode}
+  case nodes of
+    [] -> insertFirstConfig serverConfig
+    x:_  -> do
+      ClusterConfig {..} <- getClusterConfigWithId x zk
+      when (loadBalanceMode /= _loadBalanceMode) $
+        Log.warning . Log.buildString $ "Inconsistent load balance mode setting, will stay" <> show loadBalanceMode
+      insertConfig serverConfig
+  where
+    insertConfig serverConfig = void $ zooCreate
+      zk
+      (configPath <> "/" <> CB.pack (show _serverID))
+      (Just $ valueToBytes serverConfig)
+      zooOpenAclUnsafe
+      ZooEphemeral
+    insertFirstConfig serverConfig = do
+      result <- try $ zooCreate zk
+                                (configPath <> "first")
+                                Nothing
+                                zooOpenAclUnsafe
+                                ZooEphemeral
+      case result of
+        Right _                    -> insertConfig serverConfig
+        Left  (_ :: SomeException) -> checkConfigConsistent opts zk
+
+getClusterConfig :: ZHandle -> IO ClusterConfig
+getClusterConfig zk = do
+  config:_ <- unStrVec . strsCompletionValues <$> zooGetChildren zk configPath
+  getClusterConfigWithId config zk
+
+getClusterConfigWithId :: CBytes -> ZHandle -> IO ClusterConfig
+getClusterConfigWithId name zk = decodeZNodeValue' zk (configPath <> "/" <> name)
+
+getLoadBalanceMode :: ZHandle -> IO LoadBalanceMode
+getLoadBalanceMode = fmap loadBalanceMode . getClusterConfig


### PR DESCRIPTION
# PR Description

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change
- [ ] Documentation updates required

### Summary of the change and which issue is fixed

Add round-robin mode for the load balancer and also refactor.
It also removes the issue that when sometimes `getRanking` (now `getAllocatedNode`) 
failed to get from the leader, it will go into a dead loop. We solve this by using itself as the 
allocated node when failed to get node from the leader.


---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
