### PR TITLE
hstream-server: Fix `head` operation on an empty list returned by point read lastLSN

### DIFF
--- a/hstream/src/HStream/Server/Handler/Subscription.hs
+++ b/hstream/src/HStream/Server/Handler/Subscription.hs
@@ -595,7 +595,7 @@ dispatchRecords records streamSends
             initVec
             records
 
-    newSenders <- zipWithM doDispatch (HM.toList streamSends) (V.toList recordGroups)
+    newSenders <- zipWithM doDispatch (cycle . HM.toList $ streamSends) (V.toList recordGroups)
     return . HM.fromList . catMaybes $ newSenders
   where
     doDispatch (name, sender) record = do


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes: 
1. fix point read lastLSN may get an empty list and cause an exception in the doRead function
2. fix wrong use of zipWithM

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
