### PR TITLE
remove the default value in log-level option

### DIFF
--- a/hstream/src/HStream/Server/Config.hs
+++ b/hstream/src/HStream/Server/Config.hs
@@ -76,7 +76,7 @@ serverID = option auto
 logLevel :: O.Parser Log.Level
 logLevel = option auto
   $ long "log-level"
-  <> metavar "[critical|fatal|warning|info|debug]" <> value (Log.Level Log.INFO)
+  <> metavar "[critical|fatal|warning|info|debug]"
   <> help "Server log level"
 
 logWithColor :: O.Parser Bool


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 
### Summary of the change and which issue is fixed

log-level option parser shouldn't have a default value



---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
