### PR TITLE
hstream-server: streamingfetch bug fix

### DIFF
--- a/hstream/src/HStream/Server/Handler/Common.hs
+++ b/hstream/src/HStream/Server/Handler/Common.hs
@@ -93,7 +93,13 @@ insertAckedRecordId recordId lowerBound ackedRanges batchNumMap
       | canMergeToRight =
         let m1 = Map.delete (startRecordId rightRange) ackedRanges
          in Map.insert recordId (rightRange {startRecordId = recordId}) m1
-      | otherwise = Map.insert recordId (RecordIdRange recordId recordId) ackedRanges
+      | otherwise = if checkDuplicat leftRange rightRange
+                      then ackedRanges
+                      else Map.insert recordId (RecordIdRange recordId recordId) ackedRanges
+
+    checkDuplicat leftRange rightRange =
+         recordId >= startRecordId leftRange && recordId <= endRecordId leftRange
+      || recordId >= startRecordId rightRange && recordId <= endRecordId rightRange
 
 lookupLTWithDefault :: RecordId -> Map.Map RecordId RecordIdRange -> RecordIdRange
 lookupLTWithDefault recordId ranges = maybe (RecordIdRange minBound minBound) snd $ Map.lookupLT recordId ranges

--- a/hstream/test/HStream/AckSpec.hs
+++ b/hstream/test/HStream/AckSpec.hs
@@ -235,5 +235,20 @@ insertAckSpec =
       let oldRanges = Map.fromList [(gapLL, RecordIdRange gapLL gapLR), (gapRL, RecordIdRange gapRL gapRR)]
       let newRanges = Map.fromList [(gapLL, RecordIdRange gapLL gapRR)]
       insertAckedRecordId recordInsert lowerBound oldRanges batchNumMap `shouldBe` newRanges
+    it "filter duplicate ack record" $ do
+      let recordInsert1 = RecordId 5 0
+      let recordInsert2 = RecordId 7 3
+      let lowerBound = RecordId minBound minBound
+
+      let rangeLL = RecordId 2 0
+      let rangeLR = RecordId 5 8
+      let rangeRL = RecordId 6 0
+      let rangeRR = RecordId 12 5
+
+      let batchNumMap = Map.fromList [(2, 5), (5, 10), (6, 7), (12, 9)]
+      let oldRanges = Map.fromList [(rangeLL, RecordIdRange rangeLL rangeLR), (rangeRL, RecordIdRange rangeRL rangeRR)]
+      insertAckedRecordId recordInsert1 lowerBound oldRanges batchNumMap `shouldBe` oldRanges
+      insertAckedRecordId recordInsert2 lowerBound oldRanges batchNumMap `shouldBe` oldRanges
+
 
 


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes:
- Fix `streamingfetch` data loss
- Fix `insertAckedRecordId` can't deal with duplicate acked record

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
