### PR TITLE
hstream-server: Regulating the use of grpc error code

### DIFF
--- a/hstream-sql/src/HStream/SQL/Parse.hs
+++ b/hstream-sql/src/HStream/SQL/Parse.hs
@@ -23,8 +23,8 @@ parse input = do
     Left err  -> throwSQLException ParseException Nothing err
     Right sql ->
       case validate sql of
-        Left err   -> throw err
-        Right vsql -> return vsql
+        Left exception -> throw exception
+        Right vsql     -> return vsql
 
 parseAndRefine :: HasCallStack => Text -> IO RSQL
 parseAndRefine input = parse input <&> refine

--- a/hstream/src/HStream/Server/Handler/Common.hs
+++ b/hstream/src/HStream/Server/Handler/Common.hs
@@ -370,4 +370,4 @@ dropHelper sc@ServerContext{..} name checkIfExist isView = do
            else do
            Log.warning $ "Drop: tried to remove a nonexistent object: "
              <> Log.buildString (T.unpack name)
-           returnErrResp StatusInternal "Object does not exist"
+           returnErrResp StatusNotFound "Object does not exist"

--- a/hstream/src/HStream/Server/Handler/StoreAdmin.hs
+++ b/hstream/src/HStream/Server/Handler/StoreAdmin.hs
@@ -101,4 +101,4 @@ getStoreNodeHandler ServerContext{..} (ServerNormalRequest _metadata GetNodeRequ
     <> "Node ID: " <> Log.buildInt getNodeRequestId
   nodes <- getNodes headerConfig statusOpts
   let node = V.find (\(Node id' _ _ _) -> id' == getNodeRequestId) <$> nodes
-  responseWithErrorMsgIfNothing (fromMaybe Nothing node) StatusInternal "Node not exists"
+  responseWithErrorMsgIfNothing (fromMaybe Nothing node) StatusNotFound "Node not exists"

--- a/hstream/src/HStream/Server/Handler/View.hs
+++ b/hstream/src/HStream/Server/Handler/View.hs
@@ -56,7 +56,7 @@ createViewHandler sc@ServerContext{..} (ServerNormalRequest _ CreateViewRequest{
                         , viewSql = createViewRequestSql
                         , viewSchema = V.fromList $ T.pack <$> schema
                         }
-    _ -> returnErrResp StatusInternal (StatusDetails $ BSC.pack "inconsistent method called")
+    _ -> returnErrResp StatusInvalidArgument (StatusDetails $ BSC.pack "inconsistent method called")
   where
     mkLogAttrs = HS.LogAttrs . HS.HsLogAttrs scDefaultStreamRepFactor
     create sName = HS.createStream scLDClient (HCH.transToViewStreamName sName) (mkLogAttrs Map.empty)
@@ -87,7 +87,7 @@ getViewHandler ServerContext{..} (ServerNormalRequest _metadata GetViewRequest{.
     Just q -> returnResp $ hstreamQueryToView q
     _      -> do
       Log.warning $ "Cannot Find View with ID: " <> Log.buildString (T.unpack getViewRequestViewId)
-      returnErrResp StatusInternal "View does not exist"
+      returnErrResp StatusNotFound "View does not exist"
 
 deleteViewHandler
   :: ServerContext

--- a/hstream/src/HStream/Server/InternalHandler.hs
+++ b/hstream/src/HStream/Server/InternalHandler.hs
@@ -20,4 +20,4 @@ internalHandlers _ = pure HStreamInternal {
 
   }
   where
-    unimplemented = const (returnErrResp StatusInternal "unimplemented method called")
+    unimplemented = const (returnErrResp StatusUnimplemented "unimplemented method called")


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Breaking change

### Summary of the change and which issue is fixed

Main changes: 
- regulating the use of grpc error code

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
