### PR TITLE
write status while starting a server node

### DIFF
--- a/common/HStream/Utils/RPC.hs
+++ b/common/HStream/Utils/RPC.hs
@@ -18,6 +18,7 @@ module HStream.Utils.RPC
   , getServerResp
   , getProtoTimestamp
   , isSuccessful
+  , mkEnumerated
   , TaskStatus (Created, Creating, Running, CreationAbort, ConnectionAbort, Terminated, ..)
   ) where
 
@@ -85,6 +86,9 @@ getProtoTimestamp = do
 isSuccessful :: ClientResult 'Normal a -> Bool
 isSuccessful (ClientNormalResponse _ _ _ StatusOk _) = True
 isSuccessful _                                       = False
+
+mkEnumerated :: a -> PB.Enumerated a
+mkEnumerated x = PB.Enumerated (Right x)
 
 -- A type synonym could also work but the pattern synonyms defined below cannot
 -- be bundled with a type synonym when other modules import these definitions

--- a/common/proto/HStream/Server/HStreamApi.proto
+++ b/common/proto/HStream/Server/HStreamApi.proto
@@ -463,6 +463,17 @@ message ServerNode {
   uint32 port = 3;
 }
 
+enum NodeState {
+  Running = 0;
+  Terminated = 1;
+  Dead = 2;
+}
+
+message ServerNodeStatus {
+  ServerNode node = 1;
+  NodeState state = 2;
+}
+
 message LookupStreamRequest {
   string streamName = 1;
 }

--- a/hstream/src/HStream/Server/Persistence/Utils.hs
+++ b/hstream/src/HStream/Server/Persistence/Utils.hs
@@ -7,6 +7,7 @@ module HStream.Server.Persistence.Utils
   , rootPath
   , serverRootPath
   , lockPath
+  , serverRootLockPath
   , queriesPath
   , connectorsPath
   , serverLoadPath
@@ -86,6 +87,9 @@ serverRootPath = rootPath <> "/servers"
 
 lockPath :: CBytes
 lockPath = rootPath <> "/lock"
+
+serverRootLockPath :: CBytes
+serverRootLockPath = lockPath <> "/servers"
 
 queriesPath :: CBytes
 queriesPath = rootPath <> "/queries"


### PR DESCRIPTION
# PR Description

## Type of change

- [x] New feature 

### Summary of the change and which issue is fixed

Main changes: 

Every server node, when it starts, will write info of itself into the same persistent node.

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
