### PR TITLE
fix: shared subscription will not work due to inconsistency

### DIFF
--- a/hstream/src/HStream/Server/Persistence/Common.hs
+++ b/hstream/src/HStream/Server/Persistence/Common.hs
@@ -17,6 +17,7 @@ module HStream.Server.Persistence.Common
   , TaskPersistence (..)
   , BasicObjectPersistence (..)
   , ObjRepType (..)
+  , SubscriptionContext (..)
   ) where
 
 import           Data.Aeson                (FromJSON (..), FromJSONKey,
@@ -72,6 +73,10 @@ data QueryType
   | ViewQuery   RelatedStreams CBytes ViewSchema -- ^ related streams and the view it creates
   deriving (Show, Eq, Generic, FromJSON, ToJSON)
 
+newtype SubscriptionContext = SubscriptionContext
+  { subHServer :: ServerID
+  } deriving (Show, Eq, Generic, FromJSON, ToJSON)
+
 --------------------------------------------------------------------------------
 
 class TaskPersistence handle where
@@ -107,11 +112,12 @@ class TaskPersistence handle where
 
 --------------------------------------------------------------------------------
 
-data ObjRepType = SubRep
+data ObjRepType = SubRep | SubCtxRep
 
 -- | The real type of the stored object
 type family RealObjType (a :: ObjRepType) where
   RealObjType 'SubRep    = Subscription
+  RealObjType 'SubCtxRep = SubscriptionContext
 
 class (RealObjType a ~ b) => BasicObjectPersistence handle (a :: ObjRepType) b | b -> a where
   -- | persist an object to the store

--- a/hstream/src/HStream/Server/Persistence/Nodes.hs
+++ b/hstream/src/HStream/Server/Persistence/Nodes.hs
@@ -42,6 +42,7 @@ import           HStream.Server.Persistence.Utils  (decodeZNodeValue',
                                                     serverRootPath)
 import           HStream.Server.Types              (ServerID)
 import           HStream.Utils                     (cBytesToIntegral,
+                                                    integralToCBytes,
                                                     mkEnumerated, textToCBytes)
 
 data NodeInfo = NodeInfo
@@ -73,7 +74,7 @@ getServerInternalAddr zk sID = do
 
 getNodeInfo :: ZHandle -> ServerID -> IO NodeInfo
 getNodeInfo zk sID = do
-  decodeZNodeValue' zk (serverRootPath <> "/" <> CB.pack (show sID))
+  decodeZNodeValue' zk (serverRootPath <> "/" <> integralToCBytes sID)
 
 getServerNode :: ZHandle -> ServerID -> IO ServerNode
 getServerNode zk sID = do
@@ -89,7 +90,7 @@ getServerNode' :: ZHandle -> CB.CBytes -> IO ServerNode
 getServerNode' zk sID = do
   NodeInfo {..} <- decodeZNodeValue' zk (serverRootPath <> "/" <> sID)
   return $ ServerNode
-    { serverNodeId   = read . CB.unpack $ sID
+    { serverNodeId   = cBytesToIntegral sID
     , serverNodeHost = serverHost
     , serverNodePort = serverPort
     }
@@ -98,7 +99,7 @@ getServerIds :: ZHandle -> IO [ServerID]
 getServerIds zk = do
   (StringsCompletion (StringVector servers))
     <- zooGetChildren zk serverRootPath
-  return (read . CB.unpack <$> servers)
+  return (cBytesToIntegral <$> servers)
 
 getServerNodes :: ZHandle -> IO [ServerNode]
 getServerNodes zk = getServerIds zk >>= mapM (getServerNode zk)

--- a/hstream/src/HStream/Server/Persistence/Utils.hs
+++ b/hstream/src/HStream/Server/Persistence/Utils.hs
@@ -12,12 +12,15 @@ module HStream.Server.Persistence.Utils
   , connectorsPath
   , subscriptionsPath
   , subscriptionsLockPath
+  , subscriptionCtxsPath
+  , subscriptionCtxsLockPath
   , paths
 
   , initializeAncestors
   , mkQueryPath
   , mkConnectorPath
   , mkSubscriptionPath
+  , mkSubscriptionCtxPath
 
   , createInsert
   , createInsertOp
@@ -96,6 +99,12 @@ subscriptionsPath = rootPath <> "/subscriptions"
 subscriptionsLockPath :: CBytes
 subscriptionsLockPath = lockPath <> "/subscriptions"
 
+subscriptionCtxsPath :: CBytes
+subscriptionCtxsPath = rootPath <> "/subscriptionCtxs"
+
+subscriptionCtxsLockPath :: CBytes
+subscriptionCtxsLockPath = lockPath <> "/subscriptionCtxs"
+
 paths :: [CBytes]
 paths = [ "/hstreamdb"
         , rootPath
@@ -105,6 +114,8 @@ paths = [ "/hstreamdb"
         , connectorsPath
         , subscriptionsPath
         , subscriptionsLockPath
+        , subscriptionCtxsPath
+        , subscriptionCtxsLockPath
         ]
 
 initializeAncestors :: HasCallStack => ZHandle -> IO ()
@@ -119,6 +130,9 @@ mkConnectorPath x = connectorsPath <> "/" <> x
 
 mkSubscriptionPath :: T.Text -> CBytes
 mkSubscriptionPath x = subscriptionsPath <> "/" <> textToCBytes x
+
+mkSubscriptionCtxPath :: T.Text -> CBytes
+mkSubscriptionCtxPath x = subscriptionCtxsPath <> "/" <> textToCBytes x
 
 createInsert :: HasCallStack => ZHandle -> CBytes -> Bytes -> IO ()
 createInsert zk path contents = do


### PR DESCRIPTION
# PR Description

## Type of change

- [X] Bug fix 

### Summary of the change and which issue is fixed

Main changes: 

We still need SubscriptionContext to make sure of the consistency during the shared subscription. In case such when getAllocatedNode gives different results multiple subscriptions with the same subid could happen on different HServer

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
