### PR TITLE
hstream-server: support partition for creating, delete and append to a stream

### DIFF
--- a/common/HStream/Utils/BuildRecord.hs
+++ b/common/HStream/Utils/BuildRecord.hs
@@ -35,7 +35,7 @@ buildRecordHeader flag mp timestamp key =
 {-# INLINE buildRecordHeader #-}
 
 buildRecord :: HStreamRecordHeader -> ByteString -> HStreamRecord
-buildRecord header payload = HStreamRecord (Just header) payload
+buildRecord header = HStreamRecord (Just header)
 
 encodeRecord :: HStreamRecord -> ByteString
 encodeRecord = BL.toStrict . PT.toLazyByteString
@@ -61,6 +61,12 @@ getTimeStamp HStreamRecord{..} =
   let Timestamp{..} = fromJust . hstreamRecordHeaderPublishTime . fromJust $ hstreamRecordHeader
       !ts = floor @Double $ (fromIntegral timestampSeconds * 1e3) + (fromIntegral timestampNanos / 1e6)
   in ts
+
+getRecordKey :: HStreamRecord -> Maybe Text
+getRecordKey record =
+  case fmap hstreamRecordHeaderKey . hstreamRecordHeader $ record of
+    Just "" -> Nothing
+    key'    -> key'
 
 updateRecordTimestamp :: Timestamp -> HStreamRecord -> HStreamRecord
 updateRecordTimestamp timestamp HStreamRecord{..} =

--- a/common/proto/HStream/Server/HStreamApi.proto
+++ b/common/proto/HStream/Server/HStreamApi.proto
@@ -198,6 +198,7 @@ message StreamOffset {
 message DeleteStreamRequest {
   string streamName = 1;
   bool ignoreNonExist = 2;
+  bool force = 3;
 }
 
 message ListStreamsResponse {

--- a/hstream/src/HStream/Server/Core/Stream.hs
+++ b/hstream/src/HStream/Server/Core/Stream.hs
@@ -7,24 +7,31 @@ module HStream.Server.Core.Stream
   , appendStream
   ) where
 
-import qualified Data.ByteString             as BS
-import qualified Data.Map.Strict             as Map
-import qualified Data.Text                   as Text
-import qualified Data.Vector                 as V
-import           GHC.Stack                   (HasCallStack)
-import qualified Z.Data.CBytes               as CB
+import qualified Data.ByteString                  as BS
+import qualified Data.Map.Strict                  as Map
+import qualified Data.Text                        as Text
+import qualified Data.Vector                      as V
+import           GHC.Stack                        (HasCallStack)
 
-import           HStream.Connector.HStore    (transToStreamName)
-import           HStream.Server.Core.Common  (deleteStoreStream)
-import qualified HStream.Server.HStreamApi   as API
-import           HStream.Server.Types        (ServerContext (..))
-import qualified HStream.Stats               as Stats
-import qualified HStream.Store               as S
-import           HStream.ThirdParty.Protobuf as PB
+import           Control.Exception                (Handler (..), catches,
+                                                   throwIO)
+import           Data.Maybe                       (fromMaybe)
+import           HStream.Connector.HStore         (transToStreamName)
+import           HStream.Server.Core.Common       (deleteStoreStream)
+import           HStream.Server.Exception         (StreamNotExist (..))
+import qualified HStream.Server.HStreamApi        as API
+import           HStream.Server.Persistence.Utils (mkPartitionKeysPath,
+                                                   tryCreate)
+import           HStream.Server.Types             (ServerContext (..))
+import qualified HStream.Stats                    as Stats
+import qualified HStream.Store                    as S
+import           HStream.ThirdParty.Protobuf      as PB
 import           HStream.Utils
+import           ZooKeeper                        (zooExists)
 
 -------------------------------------------------------------------------------
 
+-- createStream will create a stream with a default partition
 createStream :: HasCallStack => ServerContext -> API.Stream -> IO ()
 createStream ServerContext{..} API.Stream{..} =
   S.createStream scLDClient (transToStreamName streamStreamName) $
@@ -51,17 +58,25 @@ listStreams ServerContext{..} API.ListStreamsRequest = do
 appendStream :: ServerContext -> API.AppendRequest -> IO API.AppendResponse
 appendStream ServerContext{..} API.AppendRequest{..} = do
   timestamp <- getProtoTimestamp
-  let payloads = encodeRecord . updateRecordTimestamp timestamp <$> appendRequestRecords
+  let partitionKey = getRecordKey . V.head $ appendRequestRecords
+      payloads = encodeRecord . updateRecordTimestamp timestamp <$> appendRequestRecords
       payloadSize = V.sum $ BS.length . API.hstreamRecordPayload <$> appendRequestRecords
       streamName = textToCBytes appendRequestStreamName
   -- XXX: Should we add a server option to toggle Stats?
   Stats.stream_time_series_add_append_in_bytes scStatsHolder streamName (fromIntegral payloadSize)
-  S.AppendCompletion {..} <- batchAppend scLDClient streamName payloads cmpStrategy
+
+  let prefixPath = mkPartitionKeysPath $ textToCBytes appendRequestStreamName
+  let path = prefixPath <> "/" <> (textToCBytes . fromMaybe "__default__" $ partitionKey)
+  let streamID = S.mkStreamId S.StreamTypeStream streamName
+  logId <- zooExists zkHandle path >>= \case
+    Just _ -> S.getUnderlyingLogId scLDClient streamID (textToCBytes <$> partitionKey)
+    Nothing -> do
+      logId <- catches (S.createStreamPartition scLDClient streamID (textToCBytes <$> partitionKey))
+        [ Handler (\(_ :: S.StoreError) -> throwIO StreamNotExist), -- Stream not exists
+          Handler (\(_ :: S.EXISTS) -> S.getUnderlyingLogId scLDClient streamID Nothing) -- both stream and partition are already exist
+        ]
+      tryCreate zkHandle path
+      return logId
+  S.AppendCompletion {..} <- S.appendBatchBS scLDClient logId (V.toList payloads) cmpStrategy Nothing
   let records = V.zipWith (\_ idx -> API.RecordId appendCompLSN idx) appendRequestRecords [0..]
   return $ API.AppendResponse appendRequestStreamName records
-  where
-    batchAppend :: S.LDClient -> CB.CBytes -> V.Vector BS.ByteString -> S.Compression -> IO S.AppendCompletion
-    batchAppend client streamName payloads strategy = do
-      logId <- S.getUnderlyingLogId client (S.mkStreamId S.StreamTypeStream streamName) Nothing
-      -- TODO: support vector of ByteString
-      S.appendBatchBS client logId (V.toList payloads) strategy Nothing

--- a/hstream/src/HStream/Server/Handler/Common.hs
+++ b/hstream/src/HStream/Server/Handler/Common.hs
@@ -7,9 +7,9 @@
 
 module HStream.Server.Handler.Common where
 
-import           Control.Concurrent               (ThreadId, forkIO, killThread,
-                                                   putMVar, readMVar, swapMVar,
-                                                   takeMVar)
+import           Control.Concurrent               (MVar, ThreadId, forkIO,
+                                                   killThread, putMVar,
+                                                   readMVar, swapMVar, takeMVar)
 import           Control.Exception                (Handler (Handler),
                                                    SomeException (..), catches,
                                                    displayException,
@@ -30,6 +30,7 @@ import           Data.Word                        (Word32, Word64)
 import           Database.ClickHouseDriver.Client (createClient)
 import           Database.MySQL.Base              (ERRException)
 import qualified Database.MySQL.Base              as MySQL
+import           HStream.Common.ConsistentHashing (HashRing, getAllocatedNode)
 import           Network.GRPC.HighLevel.Generated
 import           Network.GRPC.LowLevel.Op         (Op (OpRecvCloseOnServer),
                                                    OpRecvResult (OpRecvCloseOnServerResult),
@@ -387,3 +388,7 @@ dropHelper sc@ServerContext{..} name checkIfExist isView = do
            Log.warning $ "Drop: tried to remove a nonexistent object: "
              <> Log.buildString (T.unpack name)
            returnErrResp StatusNotFound "Object does not exist"
+
+shouldBeServedByThisServer :: HashRing -> Word32 -> Text -> Bool
+shouldBeServedByThisServer hashRing serverID name =
+  (== serverID) . Api.serverNodeId $ getAllocatedNode hashRing name

--- a/hstream/src/HStream/Server/Handler/Stream.hs
+++ b/hstream/src/HStream/Server/Handler/Stream.hs
@@ -17,10 +17,13 @@ where
 import qualified Data.Vector                      as V
 import           Network.GRPC.HighLevel.Generated
 
+import           Control.Concurrent               (readMVar)
 import qualified HStream.Logger                   as Log
 import qualified HStream.Server.Core.Stream       as C
 import           HStream.Server.Exception         (defaultExceptionHandle)
 import           HStream.Server.HStreamApi
+import           HStream.Server.Handler.Common    (shouldBeServedByThisServer)
+import           HStream.Server.Persistence.Utils
 import           HStream.Server.Types             (ServerContext (..))
 import           HStream.ThirdParty.Protobuf      as PB
 import           HStream.Utils
@@ -32,31 +35,47 @@ createStreamHandler
   :: ServerContext
   -> ServerRequest 'Normal Stream Stream
   -> IO (ServerResponse 'Normal Stream)
-createStreamHandler sc (ServerNormalRequest _metadata stream) = defaultExceptionHandle $ do
+createStreamHandler sc@ServerContext{..} (ServerNormalRequest _metadata stream@Stream{..}) = defaultExceptionHandle $ do
   Log.debug $ "Receive Create Stream Request: " <> Log.buildString' stream
-  C.createStream sc stream
-  returnResp stream
+  let streamPath = streamRootPath <> "/" <> textToCBytes streamStreamName
+  let keyPath = mkPartitionKeysPath (textToCBytes streamStreamName)
+  keys <- tryGetChildren zkHandle keyPath
+  if null keys
+    then do
+      let streamOp = createPathOp streamPath
+      let keyOp = createPathOp keyPath
+      tryCreateMulti zkHandle [streamOp, keyOp]
+      C.createStream sc stream
+      returnResp stream
+    else 
+      -- get here may because there is a previouse stream with same name failed to perform a deleted operation and
+      -- did not retry, or a client try to create a stream already existed.
+      returnErrResp StatusFailedPrecondition "Create failed because zk key path exists."
 
 deleteStreamHandler ::
   ServerContext ->
   ServerRequest 'Normal DeleteStreamRequest Empty ->
   IO (ServerResponse 'Normal Empty)
-deleteStreamHandler sc (ServerNormalRequest _metadata request) = defaultExceptionHandle $ do
+deleteStreamHandler sc@ServerContext{..} (ServerNormalRequest _metadata request@DeleteStreamRequest{..}) = defaultExceptionHandle $ do
   Log.debug $ "Receive Request: " <> Log.buildString' request
+  tryDeleteAllPath zkHandle (streamRootPath <> "/" <> textToCBytes deleteStreamRequestStreamName)
   C.deleteStream sc request >>= returnResp
 
-listStreamsHandler ::
-  ServerContext ->
-  ServerRequest 'Normal ListStreamsRequest ListStreamsResponse ->
-  IO (ServerResponse 'Normal ListStreamsResponse)
+listStreamsHandler 
+  :: ServerContext 
+  -> ServerRequest 'Normal ListStreamsRequest ListStreamsResponse 
+  -> IO (ServerResponse 'Normal ListStreamsResponse)
 listStreamsHandler sc (ServerNormalRequest _metadata request) = defaultExceptionHandle $ do
   Log.debug "Receive List Stream Request"
   C.listStreams sc request >>= returnResp . ListStreamsResponse
 
-appendHandler ::
-  ServerContext ->
-  ServerRequest 'Normal AppendRequest AppendResponse ->
-  IO (ServerResponse 'Normal AppendResponse)
-appendHandler sc (ServerNormalRequest _metadata request@AppendRequest{..}) = defaultExceptionHandle $ do
+appendHandler 
+  :: ServerContext 
+  -> ServerRequest 'Normal AppendRequest AppendResponse 
+  -> IO (ServerResponse 'Normal AppendResponse)
+appendHandler sc@ServerContext{..} (ServerNormalRequest _metadata request@AppendRequest{..}) = defaultExceptionHandle $ do
   Log.debug $ "Receive Append Request: StreamName {" <> Log.buildText appendRequestStreamName <> "}, nums of records = " <> Log.buildInt (V.length appendRequestRecords)
-  C.appendStream sc request >>= returnResp
+  hashRing <- readMVar loadBalanceHashRing
+  if shouldBeServedByThisServer hashRing serverID appendRequestStreamName
+    then C.appendStream sc request >>= returnResp
+    else returnErrResp StatusInvalidArgument "Send appendRequest to wrong Server."

--- a/hstream/src/HStream/Server/Handler/Stream.hs
+++ b/hstream/src/HStream/Server/Handler/Stream.hs
@@ -18,15 +18,24 @@ import qualified Data.Vector                      as V
 import           Network.GRPC.HighLevel.Generated
 
 import           Control.Concurrent               (readMVar)
+import           Control.Monad                    (void)
+import           Data.Maybe                       (isJust)
+import           HStream.Connector.HStore         (transToStreamName)
 import qualified HStream.Logger                   as Log
 import qualified HStream.Server.Core.Stream       as C
-import           HStream.Server.Exception         (defaultExceptionHandle)
+import           HStream.Server.Exception         (StreamNotExist (..),
+                                                   defaultExceptionHandle)
 import           HStream.Server.HStreamApi
-import           HStream.Server.Handler.Common    (shouldBeServedByThisServer)
+import           HStream.Server.Handler.Common    (SubscriptionStatus (..),
+                                                   getSubscriptionStatus,
+                                                   shouldBeServedByThisServer)
 import           HStream.Server.Persistence.Utils
 import           HStream.Server.Types             (ServerContext (..))
+import qualified HStream.Store                    as S
 import           HStream.ThirdParty.Protobuf      as PB
 import           HStream.Utils
+import           Z.IO.Exception                   (throwIO)
+import           ZooKeeper                        (zooExists)
 
 --------------------------------------------------------------------------------
 -- TODO: use 'HStream.Server.Core.Stream'
@@ -47,31 +56,69 @@ createStreamHandler sc@ServerContext{..} (ServerNormalRequest _metadata stream@S
       tryCreateMulti zkHandle [streamOp, keyOp]
       C.createStream sc stream
       returnResp stream
-    else 
+    else
       -- get here may because there is a previouse stream with same name failed to perform a deleted operation and
       -- did not retry, or a client try to create a stream already existed.
       returnErrResp StatusFailedPrecondition "Create failed because zk key path exists."
 
-deleteStreamHandler ::
-  ServerContext ->
-  ServerRequest 'Normal DeleteStreamRequest Empty ->
-  IO (ServerResponse 'Normal Empty)
+-- DeleteStream have two mod: force delete or normal delete
+-- For normal delete, if current stream have active subscription, the delete request will return error.
+-- For force delete, if current stream have active subscription, the stream will be archived. After that,
+-- old stream is no longer visible, current consumers can continue consume from the old subscription,
+-- but new consumers are no longer allowed to join that subscription.
+--
+-- Note: For foce delete, delivery is only guaranteed as far as possible. Which means: a consumer which
+-- terminates its consumption for any reason will have no chance to restart the consumption process.
+deleteStreamHandler
+  :: ServerContext
+  -> ServerRequest 'Normal DeleteStreamRequest Empty
+  -> IO (ServerResponse 'Normal Empty)
 deleteStreamHandler sc@ServerContext{..} (ServerNormalRequest _metadata request@DeleteStreamRequest{..}) = defaultExceptionHandle $ do
-  Log.debug $ "Receive Request: " <> Log.buildString' request
-  tryDeleteAllPath zkHandle (streamRootPath <> "/" <> textToCBytes deleteStreamRequestStreamName)
-  C.deleteStream sc request >>= returnResp
+  Log.debug $ "Receive Delete Stream Request: " <> Log.buildString' request
+  zNodeExists <- checkZkPathExist
+  storeExists <- checkStreamExist
+  case (zNodeExists, storeExists) of
+    -- normal path
+    (True, True) -> doDelete deleteStreamRequestForce
+    -- if we delete stream but failed to clear zk path, we will get here when client retry the delete request
+    (True, False) -> cleanZkNode >> returnResp Empty
+    -- actually, it should not be here because we always delete stream before clear zk path, get here may
+    -- means some unexpected error. since it is a delete request and we just want to destroy the resouce, so
+    -- it could be fine to just delete the stream instead of throw an exception
+    (False, True) -> C.deleteStream sc request >> returnResp Empty
+    -- get here may because we meet a concurrency problem, or we finished delete request but client lose the
+    -- response and retry
+    (False, False) -> if deleteStreamRequestIgnoreNonExist then returnResp Empty else throwIO StreamNotExist
+  where
+    streamPath = streamRootPath <> "/" <> textToCBytes deleteStreamRequestStreamName
+    streamName = transToStreamName deleteStreamRequestStreamName
+    cleanZkNode = deleteAllPath zkHandle streamPath
+    checkZkPathExist = isJust <$> zooExists zkHandle streamPath
+    checkStreamExist = S.doesStreamExist scLDClient streamName
+    checkIfActive = (== Active) <$> getSubscriptionStatus scLDClient streamName
 
-listStreamsHandler 
-  :: ServerContext 
-  -> ServerRequest 'Normal ListStreamsRequest ListStreamsResponse 
+    doDelete False = do
+      isActive <- checkIfActive
+      if isActive
+        then returnErrResp StatusFailedPrecondition "Can not delete stream with active subscription."
+        else C.deleteStream sc request >> cleanZkNode >> returnResp Empty
+    doDelete True = do
+      isActive <- checkIfActive
+      if isActive then S.archiveStream scLDClient streamName
+                  else void $ C.deleteStream sc request
+      cleanZkNode >> returnResp Empty
+
+listStreamsHandler
+  :: ServerContext
+  -> ServerRequest 'Normal ListStreamsRequest ListStreamsResponse
   -> IO (ServerResponse 'Normal ListStreamsResponse)
 listStreamsHandler sc (ServerNormalRequest _metadata request) = defaultExceptionHandle $ do
   Log.debug "Receive List Stream Request"
   C.listStreams sc request >>= returnResp . ListStreamsResponse
 
-appendHandler 
-  :: ServerContext 
-  -> ServerRequest 'Normal AppendRequest AppendResponse 
+appendHandler
+  :: ServerContext
+  -> ServerRequest 'Normal AppendRequest AppendResponse
   -> IO (ServerResponse 'Normal AppendResponse)
 appendHandler sc@ServerContext{..} (ServerNormalRequest _metadata request@AppendRequest{..}) = defaultExceptionHandle $ do
   Log.debug $ "Receive Append Request: StreamName {" <> Log.buildText appendRequestStreamName <> "}, nums of records = " <> Log.buildInt (V.length appendRequestRecords)

--- a/hstream/src/HStream/Server/Persistence/Utils.hs
+++ b/hstream/src/HStream/Server/Persistence/Utils.hs
@@ -33,6 +33,7 @@ module HStream.Server.Persistence.Utils
   , deleteAllPath
   , tryDeleteAllPath
   , tryCreateMulti
+  , tryGetChildren
   , decodeDataCompletion
   , decodeDataCompletion'
   , decodeZNodeValue
@@ -62,7 +63,8 @@ import qualified Z.Foreign                            as ZF
 import           ZooKeeper                            (Resource, zooCreate,
                                                        zooCreateOpInit,
                                                        zooDelete, zooDeleteAll,
-                                                       zooGet, zooMulti, zooSet,
+                                                       zooGet, zooGetChildren,
+                                                       zooMulti, zooSet,
                                                        zooSetOpInit,
                                                        zookeeperResInit)
 import           ZooKeeper.Exception
@@ -180,6 +182,12 @@ tryDeleteAllPath :: HasCallStack => ZHandle -> CBytes -> IO ()
 tryDeleteAllPath zk path = catch (deleteAllPath zk path) $
   \(_ :: ZNONODE) -> do
     pure ()
+
+tryGetChildren :: HasCallStack => ZHandle -> CBytes -> IO [CBytes]
+tryGetChildren zk path = catch getChildren $
+  \(_ :: ZNONODE) -> pure []
+  where
+    getChildren = unStrVec . strsCompletionValues <$> zooGetChildren zk path
 
 decodeDataCompletion :: FromJSON a => DataCompletion -> Maybe a
 decodeDataCompletion (DataCompletion (Just x) _) =


### PR DESCRIPTION
# PR Description

## Type of change

- [x] New feature 
- [x] Breaking change

### Summary of the change and which issue is fixed

Main changes: 
- support partition for creating stream and append to stream
- modify deleteStream proto to support force delete a stream
- refine the deleteStream function

Details:
- add a new zookeeper path `/hstreamdb/streams/{streamName}/keys/{key}` to support dynamic partitioning
    -  Path `/hstreamdb/streams/{streamName}/keys/` will be created in `createStream` function, and the sub path
       `xxx/{streamName}/xxx` will be removed in `deleteStream` function.
    - when server receive an append request with a new partition key, it will create the sub path `xxx/{streamName}/keys/{key}`, then other servers can be notified by watching the path `xxx/{streamName}/keys`.

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
