### PR TITLE
hstream-server: add partition key to verify serverID when handle append req

### DIFF
--- a/hstream/src/HStream/Server/Handler/Stream.hs
+++ b/hstream/src/HStream/Server/Handler/Stream.hs
@@ -26,9 +26,7 @@ import qualified HStream.Server.Core.Stream       as C
 import           HStream.Server.Exception         (StreamNotExist (..),
                                                    defaultExceptionHandle)
 import           HStream.Server.HStreamApi
-import           HStream.Server.Handler.Common    (SubscriptionStatus (..),
-                                                   getSubscriptionStatus,
-                                                   shouldBeServedByThisServer)
+import           HStream.Server.Handler.Common    (shouldBeServedByThisServer)
 import           HStream.Server.Persistence.Utils
 import           HStream.Server.Types             (ServerContext (..))
 import qualified HStream.Store                    as S
@@ -123,6 +121,10 @@ appendHandler
 appendHandler sc@ServerContext{..} (ServerNormalRequest _metadata request@AppendRequest{..}) = defaultExceptionHandle $ do
   Log.debug $ "Receive Append Request: StreamName {" <> Log.buildText appendRequestStreamName <> "}, nums of records = " <> Log.buildInt (V.length appendRequestRecords)
   hashRing <- readMVar loadBalanceHashRing
-  if shouldBeServedByThisServer hashRing serverID appendRequestStreamName
-    then C.appendStream sc request >>= returnResp
+  let partitionKey = getRecordKey . V.head $ appendRequestRecords
+  let identifier = case partitionKey of
+                     Just key -> appendRequestStreamName <> key
+                     Nothing  -> appendRequestStreamName
+  if shouldBeServedByThisServer hashRing serverID identifier
+    then C.appendStream sc request partitionKey >>= returnResp
     else returnErrResp StatusInvalidArgument "Send appendRequest to wrong Server."


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes: 
- add partition key when calculating consistency hash in appendHandler

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
