### PR TITLE
cli: abort on `C-c`, rm client-admin stats table

### DIFF
--- a/hstream-sql/etc/SQL.cf
+++ b/hstream-sql/etc/SQL.cf
@@ -38,7 +38,6 @@ comment "/*" "*/" ;
 
 entrypoints SQL ;
 
-QSelectStats. SQL ::= SelectStats ";" ;
 QSelectView.  SQL ::= SelectView  ";" ;
 QSelect.      SQL ::= Select      ";" ;
 QCreate.      SQL ::= Create      ";" ;
@@ -313,19 +312,3 @@ CompOpLT.  CompOp ::= "<" ;
 CompOpGT.  CompOp ::= ">" ;
 CompOpLEQ. CompOp ::= "<=" ;
 CompOpGEQ. CompOp ::= ">=" ;
-
---------------------------------------------------------------------------------
-DSelectStats. SelectStats ::= "ADMIN::" SelectAdmin StatsWhere      ;
-DSelectAdmin. SelectAdmin ::= "SELECT" StatsItems "FROM" StatsTable ;
-
-StatsItemAll.  StatsItems ::= "*"          ;
-StatsItemList. StatsItems ::= [StatsIdent] ;
-
-DStatsIdent. StatsIdent ::= Ident ;
-separator StatsIdent ","          ;
-
-StatsTableAppendInBytes. StatsTable ::= "APPEND_THROUGHPUT" ;
-StatsTableRecordBytes.   StatsTable ::= "READ_THROUGHPUT"    ;
-
-StatsWhereNil.  StatsWhere ::= ""                                ;
-StatsWhereCons. StatsWhere ::= "WHERE" "STREAM" "=" [StatsIdent] ;

--- a/hstream-sql/src/HStream/SQL/AST.hs
+++ b/hstream-sql/src/HStream/SQL/AST.hs
@@ -539,33 +539,6 @@ instance Refine Terminate where
   refine (TerminateAll   _  ) = RTerminateAll
 type instance RefinedType Terminate = RTerminate
 
----- Select Stats
-data RSelectStats
-  = RSelectStats [Text] RStatsTable [StreamName]
-  deriving (Eq, Show)
-
-data RStatsTable = AppendInBytes | RecordBytes deriving (Eq, Show)
-type instance RefinedType StatsTable = RStatsTable
-instance Refine StatsTable where
-  refine = \case
-    StatsTableAppendInBytes _ -> AppendInBytes
-    StatsTableRecordBytes   _ -> RecordBytes
-
-type instance RefinedType SelectStats = RSelectStats
-instance Refine SelectStats where
-  refine = \case
-    DSelectStats _ (DSelectAdmin _ statsItems statsTable) statsConds -> RSelectStats
-      (rStatsItems statsItems)
-      (refine      statsTable)
-      (rStatsConds statsConds)
-    where
-    rStatsItems = \case
-      StatsItemAll  _    -> []
-      StatsItemList _ xs -> xs <&> \(DStatsIdent _ (Ident x)) -> x
-    rStatsConds = \case
-      StatsWhereNil  _    -> []
-      StatsWhereCons _ xs -> xs <&> \(DStatsIdent _ (Ident x)) -> x
-
 ---- SQL
 data RSQL = RQSelect      RSelect
           | RQCreate      RCreate
@@ -574,7 +547,6 @@ data RSQL = RQSelect      RSelect
           | RQDrop        RDrop
           | RQTerminate   RTerminate
           | RQSelectView  RSelectView
-          | RQSelectStats RSelectStats
           | RQExplain     RExplain
           deriving (Eq, Show)
 type instance RefinedType SQL = RSQL
@@ -586,7 +558,6 @@ instance Refine SQL where
   refine (QDrop        _    drop_) = RQDrop        (refine    drop_)
   refine (QTerminate   _     term) = RQTerminate   (refine     term)
   refine (QSelectView  _  selView) = RQSelectView  (refine  selView)
-  refine (QSelectStats _ selStats) = RQSelectStats (refine selStats)
   refine (QExplain     _  explain) = RQExplain     (refine  explain)
 
 --------------------------------------------------------------------------------

--- a/hstream-sql/src/HStream/SQL/Codegen.hs
+++ b/hstream-sql/src/HStream/SQL/Codegen.hs
@@ -485,7 +485,7 @@ fuseAggregateComponents components =
 genGroupByNode :: RSelect
                -> Stream Object Object SerPipe
                -> IO (Either (Stream Object Object SerPipe) (Stream (TimeWindowKey Object) Object SerPipe), Materialized Object Object SerMat)
-genGroupByNode (RSelect _ _ _ RGroupByEmpty _ ) s =
+genGroupByNode (RSelect _ _ _ RGroupByEmpty _ ) _ =
   throwSQLException CodegenException Nothing "Impossible happened"
 genGroupByNode (RSelect sel _ _ grp@(RGroupBy stream' field win') _) s = do
   grped <- HS.groupBy

--- a/hstream-sql/src/HStream/SQL/Internal/Validate.hs
+++ b/hstream-sql/src/HStream/SQL/Internal/Validate.hs
@@ -735,15 +735,10 @@ instance Validate Drop where
 instance Validate Terminate where
   validate = return
 
-------------------------------------- Select Stats -----------------------------
-instance Validate SelectStats where
-  validate = return
-
 ------------------------------------- SQL --------------------------------------
 instance Validate SQL where
   validate sql@(QSelect      _   select) = validate select   >> return sql
   validate sql@(QSelectView  _  selView) = validate selView  >> return sql
-  validate sql@(QSelectStats _ selStats) = validate selStats >> return sql
   validate sql@(QCreate      _   create) = validate create   >> return sql
   validate sql@(QInsert      _   insert) = validate insert   >> return sql
   validate sql@(QShow        _    show_) = validate show_    >> return sql


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix
- [x] Breaking change

### Summary of the change and which issue is fixed

Main changes:
- fix built-in Ctrl-C handling
- remove `hstream-client` admin stats table

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
