### PR TITLE
hstream-server: refactor streamingFetch handler

### DIFF
--- a/common/HStream/Utils.hs
+++ b/common/HStream/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 module HStream.Utils
   ( module HStream.Utils.Converter
   , module HStream.Utils.Format
@@ -10,6 +12,7 @@ module HStream.Utils
   , module HStream.Utils.JSON
 
   , genUnique
+  , currentTimestampMS
   ) where
 
 import           Control.Monad              (unless)
@@ -50,3 +53,9 @@ genUnique = do
        .|. fromIntegral (shiftL tsBit' 16)
        .|. fromIntegral rdmBit
 {-# INLINE genUnique #-}
+
+currentTimestampMS :: IO Int64
+currentTimestampMS = do
+  MkSystemTime sec nano <- getSystemTime'
+  let !ts = floor @Double $ (fromIntegral sec * 1e3) + (fromIntegral nano / 1e6)
+  return ts

--- a/hstream/src/HStream/Server/Exception.hs
+++ b/hstream/src/HStream/Server/Exception.hs
@@ -8,7 +8,7 @@
 module HStream.Server.Exception where
 
 import           Control.Exception                    (Exception (..),
-                                                       Handler (Handler),
+                                                       Handler (..),
                                                        IOException,
                                                        SomeException, catches,
                                                        displayException)
@@ -132,9 +132,10 @@ newtype ConsumerExist = ConsumerExist Text
 instance Exception ConsumerExist
 
 data SubscribeInnerError = GRPCStreamRecvError
-                             | GRPCStreamRecvCloseError
-                             | GRPCStreamSendError
-                             | ConsumerInValidError
+                         | GRPCStreamRecvCloseError
+                         | GRPCStreamSendError
+                         | ConsumerInValidError
+                         | StoreError Store.SomeHStoreException
   deriving (Show)
 instance Exception SubscribeInnerError
 


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Refactor
### Summary of the change and which issue is fixed

Main changes: 
refactor streamingFetch handler.

Basic idea:
- the client will send a streamingFetchRequest RPC for every subscription key, which means the fetch process for each key is independent of each other, and the associated state exists only in memory. If the fetch thread is destroyed, the associated state also should be destroyed. So we can use a thread local variable to keep the state associated with each key. This way, we can avoid lock/unlock everywhere and stay simple when cleaning up resources.
- for each fetch process, separate slow IO operations to be executed in a sub-thread, put all operations involving state modification into the main thread for serial execution. using channels to gather different events send from sub-thread so that we can avoid using lock explicit. 
  - currently, we have these events:
    - ACKTIMEOUT: which will trigger a retransmission
    - ACK: received acks from client
    - DATAREADY: get records from hstore and notify server to send to client
    - STOP: stop the whole fetch process
  - also it's easy to add/remove an event if needed and make the program easy to scalable.

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
