### PR TITLE
hstream-server: fix duplicated consumerName for same subscription

### DIFF
--- a/hstream/src/HStream/Server/Types.hs
+++ b/hstream/src/HStream/Server/Types.hs
@@ -119,12 +119,13 @@ type ConsumerName = T.Text
 --   , sriSignals           :: V.Vector (MVar ())
 -- }
 
-data SubscribeRuntimeInfo = SubscribeRuntimeInfo {
-    sriSubscriptionId :: SubscriptionId
+data SubscribeRuntimeInfo = SubscribeRuntimeInfo
+  { sriSubscriptionId :: SubscriptionId
   , sriStreamName :: T.Text
   , sriWatchContext :: MVar WatchContext
+  , sriConsumers :: Set.Set ConsumerName
   , sriShardRuntimeInfo :: MVar (HM.HashMap OrderingKey (MVar ShardSubscribeRuntimeInfo))
-}
+  }
 
 data WatchContext = WatchContext {
     wcWaitingConsumers :: [ConsumerWatch]


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes: 
- fix: duplicated consumerName for same subscription should return error response

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
