### PR TITLE
ci: only run basic tests, upload logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,16 +155,25 @@ jobs:
       - name: fetch integration tests source code
         uses: actions/checkout@v2
         with:
-          repository: 'hstreamdb/integration-tests'
+          repository: "hstreamdb/integration-tests"
           path: integration-tests
 
       - uses: actions/setup-java@v2
         with:
           distribution: "adopt"
           java-version: 11
-          cache: 'gradle'
+          cache: "gradle"
 
       - uses: gradle/wrapper-validation-action@v1
 
       - name: run integration tests
-        run: "cd integration-tests && export HSTREAM_IMAGE_NAME=$NEW_HSTREAM_IMAGE && ./gradlew test"
+        run: 'cd integration-tests && export HSTREAM_IMAGE_NAME=$NEW_HSTREAM_IMAGE && gradle :app:test --debug --tests "io.hstream.testing.BasicTest"'
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ success() }} || ${{ failure() }}
+        with:
+          name: integration-tests-reports
+          path: |
+            integration-tests/.logs
+            integration-tests/app/build/reports
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
 
       - name: run integration tests
-        run: 'cd integration-tests && export HSTREAM_IMAGE_NAME=$NEW_HSTREAM_IMAGE && gradle :app:test --debug --tests "io.hstream.testing.BasicTest"'
+        run: 'cd integration-tests && export HSTREAM_IMAGE_NAME=$NEW_HSTREAM_IMAGE && ./gradlew :app:test --debug --tests "io.hstream.testing.BasicTest"'
 
       - uses: actions/upload-artifact@v2
         if: ${{ success() }} || ${{ failure() }}


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes: only run basic tests, upload logs

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
