### PR TITLE
fix: fix append error when log group is not prepared

### DIFF
--- a/hstream/src/HStream/Server/Exception.hs
+++ b/hstream/src/HStream/Server/Exception.hs
@@ -86,6 +86,15 @@ mkExceptionHandle retFun cleanFun = flip catches [
 defaultExceptionHandle :: IO (ServerResponse 'Normal a) -> IO (ServerResponse 'Normal a)
 defaultExceptionHandle = mkExceptionHandle returnErrResp $ return ()
 
+appendStreamExceptionHandle :: IO (ServerResponse 'Normal a) -> IO (ServerResponse 'Normal a)
+appendStreamExceptionHandle action = defaultExceptionHandle $ catches action [
+  Handler (\(err :: Store.NOTFOUND) -> do
+    returnErrResp StatusUnavailable $ StatusDetails (BS.pack (show err))),
+  Handler (\(err :: Store.NOTINSERVERCONFIG) -> do
+    returnErrResp StatusUnavailable $ StatusDetails (BS.pack (show err)))
+  ]
+
+
 defaultExceptionHandle' :: IO () -> IO (ServerResponse 'Normal a) -> IO (ServerResponse 'Normal a)
 defaultExceptionHandle' = mkExceptionHandle returnErrResp
 

--- a/hstream/src/HStream/Server/Exception.hs
+++ b/hstream/src/HStream/Server/Exception.hs
@@ -12,6 +12,7 @@ import           Control.Exception                    (Exception (..),
                                                        IOException,
                                                        SomeException, catches,
                                                        displayException)
+import qualified Control.Exception                    as CE
 import qualified Data.ByteString.Char8                as BS
 import           Data.Text                            (Text)
 import           Data.Text.Encoding                   (encodeUtf8)
@@ -30,12 +31,12 @@ import           Network.GRPC.HighLevel.Client
 import           Network.GRPC.HighLevel.Server
 import           ZooKeeper.Exception
 
--- TODO: More exception handle needs specific handling.
-mkExceptionHandle :: (StatusCode -> StatusDetails -> IO (ServerResponse t a))
-                  -> IO ()
-                  -> IO (ServerResponse t a)
-                  -> IO (ServerResponse t a)
-mkExceptionHandle retFun cleanFun = flip catches [
+type RetFun t a = (StatusCode -> StatusDetails -> IO (ServerResponse t a))
+type CleanFun = IO ()
+type Handlers t a = [CE.Handler (ServerResponse t a)]
+
+defaultHandlers :: RetFun t a -> CleanFun -> Handlers t a
+defaultHandlers retFun cleanFun = [
   Handler (\(err :: SomeSQLException) ->
     retFun StatusInvalidArgument $ StatusDetails (BS.pack . formatSomeSQLException $ err)),
   Handler (\(_ :: Store.EXISTS) ->
@@ -83,28 +84,31 @@ mkExceptionHandle retFun cleanFun = flip catches [
     retFun StatusUnknown $ StatusDetails ("UnKnown exception: " <> BS.pack (show err)))
   ]
 
+mkExceptionHandle :: Handlers t a -> IO (ServerResponse t a) -> IO (ServerResponse t a)
+mkExceptionHandle = flip catches
+
 defaultExceptionHandle :: IO (ServerResponse 'Normal a) -> IO (ServerResponse 'Normal a)
-defaultExceptionHandle = mkExceptionHandle returnErrResp $ return ()
+defaultExceptionHandle = mkExceptionHandle $ defaultHandlers returnErrResp (return ())
 
 appendStreamExceptionHandle :: IO (ServerResponse 'Normal a) -> IO (ServerResponse 'Normal a)
-appendStreamExceptionHandle action = defaultExceptionHandle $ catches action [
+appendStreamExceptionHandle = mkExceptionHandle $ [
   Handler (\(err :: Store.NOTFOUND) -> do
     returnErrResp StatusUnavailable $ StatusDetails (BS.pack (show err))),
   Handler (\(err :: Store.NOTINSERVERCONFIG) -> do
     returnErrResp StatusUnavailable $ StatusDetails (BS.pack (show err)))
-  ]
+  ] ++ defaultHandlers returnErrResp (return ())
 
 
 defaultExceptionHandle' :: IO () -> IO (ServerResponse 'Normal a) -> IO (ServerResponse 'Normal a)
-defaultExceptionHandle' = mkExceptionHandle returnErrResp
+defaultExceptionHandle' = mkExceptionHandle . defaultHandlers returnErrResp
 
 defaultServerStreamExceptionHandle :: IO (ServerResponse 'ServerStreaming a)
                                    -> IO (ServerResponse 'ServerStreaming a)
-defaultServerStreamExceptionHandle = mkExceptionHandle returnServerStreamingResp $ return ()
+defaultServerStreamExceptionHandle = mkExceptionHandle $ defaultHandlers returnServerStreamingResp (return ())
 
 defaultBiDiStreamExceptionHandle :: IO (ServerResponse 'BiDiStreaming a)
                                  -> IO (ServerResponse 'BiDiStreaming a)
-defaultBiDiStreamExceptionHandle = mkExceptionHandle returnBiDiStreamingResp $ return ()
+defaultBiDiStreamExceptionHandle = mkExceptionHandle $ defaultHandlers returnBiDiStreamingResp (return ())
 
 data QueryTerminatedOrNotExist = QueryTerminatedOrNotExist
   deriving (Show)

--- a/hstream/src/HStream/Server/Handler/Stream.hs
+++ b/hstream/src/HStream/Server/Handler/Stream.hs
@@ -21,7 +21,8 @@ import           Control.Concurrent               (readMVar)
 import           HStream.Common.ConsistentHashing (getAllocatedNodeId)
 import qualified HStream.Logger                   as Log
 import qualified HStream.Server.Core.Stream       as C
-import           HStream.Server.Exception         (defaultExceptionHandle)
+import           HStream.Server.Exception         (appendStreamExceptionHandle,
+                                                   defaultExceptionHandle)
 import           HStream.Server.HStreamApi
 import           HStream.Server.Handler.Common    (clientDefaultKey)
 import           HStream.Server.Types             (ServerContext (..))
@@ -66,7 +67,7 @@ appendHandler
   :: ServerContext
   -> ServerRequest 'Normal AppendRequest AppendResponse
   -> IO (ServerResponse 'Normal AppendResponse)
-appendHandler sc@ServerContext{..} (ServerNormalRequest _metadata request@AppendRequest{..}) = defaultExceptionHandle $ do
+appendHandler sc@ServerContext{..} (ServerNormalRequest _metadata request@AppendRequest{..}) = appendStreamExceptionHandle $ do
   Log.debug $ "Receive Append Request: StreamName {" <> Log.buildText appendRequestStreamName <> "}, nums of records = " <> Log.buildInt (V.length appendRequestRecords)
   hashRing <- readMVar loadBalanceHashRing
   let partitionKey = getRecordKey . V.head $ appendRequestRecords


### PR DESCRIPTION
# PR Description

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Documentation updates required

### Summary of the change and which issue is fixed

Main changes: set grpc status to unavailable when append failed in case of unprepared log group, client will retry. 

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
