### PR TITLE
hstream-server: protect ldreader with MVar

### DIFF
--- a/hstream/src/HStream/Server/Handler/Subscription.hs
+++ b/hstream/src/HStream/Server/Handler/Subscription.hs
@@ -224,11 +224,11 @@ doSubInit ctx@ServerContext{..} subId = do
       -- create a ldCkpReader for reading new records
       ldCkpReader <-
         S.newLDRsmCkpReader scLDClient readerName S.checkpointStoreLogID 5000 maxReadLogs (Just ldReaderBufferSize) 5
-      S.ckpReaderSetTimeout ldCkpReader 10
+      void $ S.ckpReaderSetTimeout ldCkpReader 10
       Log.debug $ "created a ldCkpReader for subscription {" <> Log.buildText subId <> "}"
 
       -- create a ldReader for rereading unacked records
-      ldReader <- S.newLDReader scLDClient maxReadLogs (Just ldReaderBufferSize)
+      ldReader <- newMVar =<< S.newLDReader scLDClient maxReadLogs (Just ldReaderBufferSize)
       Log.debug $ "created a ldReader for subscription {" <> Log.buildText subId <> "}"
 
       consumerContexts <- newTVarIO HM.empty
@@ -246,7 +246,7 @@ doSubInit ctx@ServerContext{..} subId = do
                 subAssignment = assignment
               }
       shards <- getShards ctx subscriptionStreamName
-      Log.debug $ "get shards: " <> (Log.buildString $ show shards)
+      Log.debug $ "get shards: " <> Log.buildString (show shards)
       addNewShardsToSubCtx emptySubCtx shards
       return emptySubCtx
   where
@@ -514,8 +514,9 @@ sendRecords ctx@ServerContext {..} subState subCtx@SubscribeContext {..} = do
       if V.null resendRecordIds
       then return ()
       else do
-        S.readerStartReading subLdReader logId batchId batchId
-        dataRecord <- S.readerRead subLdReader 1
+        dataRecord <- withMVar subLdReader $ \reader -> do
+          S.readerStartReading reader logId batchId batchId
+          S.readerRead reader 1
         if length dataRecord /= 1
         then do
           -- TODO: handle error here

--- a/hstream/src/HStream/Server/Types.hs
+++ b/hstream/src/HStream/Server/Types.hs
@@ -6,9 +6,8 @@
 
 module HStream.Server.Types where
 
-import           Control.Concurrent               (MVar, ThreadId, newEmptyMVar)
+import           Control.Concurrent               (MVar, ThreadId)
 import           Control.Concurrent.STM
-import           Data.Aeson                       (FromJSON, ToJSON)
 import           Data.ByteString                  (ByteString)
 import qualified Data.HashMap.Strict              as HM
 import           Data.Int                         (Int32, Int64)
@@ -16,7 +15,6 @@ import qualified Data.Map                         as Map
 import qualified Data.Set                         as Set
 import qualified Data.Text                        as T
 import           Data.Word                        (Word32, Word64)
-import           GHC.Generics                     (Generic)
 import           Network.GRPC.HighLevel           (StreamSend)
 import qualified Z.Data.CBytes                    as CB
 import           Z.Data.CBytes                    (CBytes)
@@ -101,7 +99,7 @@ data SubscribeContext = SubscribeContext
     subStreamName        :: T.Text,
     subAckTimeoutSeconds :: Int32,
     subLdCkpReader       :: HS.LDSyncCkpReader,
-    subLdReader          :: HS.LDReader,
+    subLdReader          :: MVar HS.LDReader,
     subConsumerContexts  :: TVar (HM.HashMap ConsumerName ConsumerContext),
     subShardContexts     :: TVar (HM.HashMap HS.C_LogID SubscribeShardContext),
     subAssignment        :: Assignment


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes: 
fix: concurrent calls to the ldreader to read the retransmitted data will result in a coredump

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
