### PR TITLE
fix: Ord definition of ConsumerWorkload

### DIFF
--- a/hstream/src/HStream/Server/Types.hs
+++ b/hstream/src/HStream/Server/Types.hs
@@ -128,11 +128,11 @@ data Assignment = Assignment
 data ConsumerWorkload = ConsumerWorkload
   { cwConsumerName :: ConsumerName,
     cwShardCount   :: Int
-  }
+  } deriving (Show)
 instance Eq ConsumerWorkload where
   (==) w1 w2 = cwConsumerName w1 == cwConsumerName w2 && cwShardCount w1 == cwShardCount w2
 instance Ord ConsumerWorkload where
-  (<=) w1 w2 = w1 == w2 || cwShardCount w1 <= cwShardCount w2
+  (<=) w1 w2 = (cwShardCount w1, cwConsumerName w1) <= (cwShardCount w2, cwConsumerName w2)
 
 type SubscriptionId = T.Text
 type OrderingKey = T.Text


### PR DESCRIPTION
# PR Description

## Type of change

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Documentation updates required

### Summary of the change and which issue is fixed

Main changes: The Ord definition of ConsumerWorkload should satisfy the properties of a total order, or may cause some unexpected behavior(e.g. Set.delete, https://github.com/hstreamdb/hstream/blob/78fd6d6c9bab7898bef6de15442b6635733d0728/hstream/src/HStream/Server/Handler/Subscription.hs#L696).

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
