### PR TITLE
[skip ci] dev-deploy: opts for `node_exporter`

### DIFF
--- a/script/dev-deploy
+++ b/script/dev-deploy
@@ -1026,7 +1026,10 @@ class NodeExporterService(Service):
                     f"{docker_opts} "
                     f"--name {container_name} "
                     f"--network host "
-                    f"{image}"
+                    f"--pid=host "
+                    f'-v "/:/host:ro,rslave" '
+                    f"{image} "
+                    f"--path.rootfs=/host"
                     f"'"
                 )
         return cmds


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes: as

```shell
docker run -d \
  --net="host" \
  --pid="host" \
  -v "/:/host:ro,rslave" \
  quay.io/prometheus/node-exporter:latest \
  --path.rootfs=/host
```

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
