### PR TITLE
add Shard module to support manipulate shards

### DIFF
--- a/hstream-store/HStream/Store/Stream.hs
+++ b/hstream-store/HStream/Store/Stream.hs
@@ -17,6 +17,7 @@ module HStream.Store.Stream
     -- ** Operations
   , createStream
   , createStreamPartition
+  , createStreamPartitionWithExtrAttr
   , renameStream
   , renameStream'
   , archiveStream
@@ -269,6 +270,21 @@ createStreamPartition client streamid m_key = do
   if stream_exist
      then do (log_path, _key) <- getStreamLogPath streamid m_key
              createRandomLogGroup client log_path def
+     else E.throwStoreError ("No such stream: " <> ZT.pack (showStreamName streamid))
+                            callStack
+
+createStreamPartitionWithExtrAttr
+  :: HasCallStack
+  => FFI.LDClient
+  -> StreamId
+  -> Maybe CBytes
+  -> Map CBytes CBytes
+  -> IO FFI.C_LogID
+createStreamPartitionWithExtrAttr client streamid m_key attr = do
+  stream_exist <- doesStreamExist client streamid
+  if stream_exist
+     then do (log_path, _key) <- getStreamLogPath streamid m_key
+             createRandomLogGroup client log_path def {LD.logAttrsExtras = attr}
      else E.throwStoreError ("No such stream: " <> ZT.pack (showStreamName streamid))
                             callStack
 

--- a/hstream-store/HStream/Store/Stream.hs
+++ b/hstream-store/HStream/Store/Stream.hs
@@ -266,12 +266,7 @@ createStreamPartition
   -> Maybe CBytes
   -> IO FFI.C_LogID
 createStreamPartition client streamid m_key = do
-  stream_exist <- doesStreamExist client streamid
-  if stream_exist
-     then do (log_path, _key) <- getStreamLogPath streamid m_key
-             createRandomLogGroup client log_path def
-     else E.throwStoreError ("No such stream: " <> ZT.pack (showStreamName streamid))
-                            callStack
+  createStreamPartitionWithExtrAttr client streamid m_key Map.empty
 
 createStreamPartitionWithExtrAttr
   :: HasCallStack

--- a/hstream/hstream.cabal
+++ b/hstream/hstream.cabal
@@ -127,6 +127,8 @@ library
     , Z-Data
     , Z-IO
     , zoovisitor
+    , cryptonite
+    , memory
 
   default-language:   Haskell2010
   default-extensions:
@@ -170,6 +172,8 @@ executable hstream-server
     , Z-Data
     , Z-IO
     , zoovisitor
+    , cryptonite
+    , memory
 
   default-language: Haskell2010
   ghc-options:

--- a/hstream/hstream.cabal
+++ b/hstream/hstream.cabal
@@ -58,6 +58,7 @@ library
     HStream.Server.Persistence.Exception
     HStream.Server.Types
     HStream.Server.ReaderPool
+    HStream.Server.Shard
 
   other-modules:
     HStream.Server.Core.Common
@@ -222,6 +223,7 @@ test-suite hstream-test
     HStream.RunStoreAdminSpec
     HStream.SpecUtils
     HStream.StatsIntegrationSpec
+    HStream.ShardSpec
 
   hs-source-dirs:     test
   build-depends:
@@ -250,6 +252,7 @@ test-suite hstream-test
     , Z-Data
     , Z-IO
     , zoovisitor
+    , QuickCheck
 
   default-language:   Haskell2010
   default-extensions:

--- a/hstream/src/HStream/Server/Shard.hs
+++ b/hstream/src/HStream/Server/Shard.hs
@@ -1,133 +1,272 @@
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ExistentialQuantification #-} 
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE OverloadedStrings         #-}
 
-module HStream.Server.Shard where
+module HStream.Server.Shard (
+    ShardKey,
+    hashShardKey,
+    Shard,
+    mkShard,
+    SharedShardMap,
+    getShardMap,
+    putShardMap,
+    splitByKey,
+    splitHalf,
+    mergeTwoShard,
+    createShard,
+    mkSharedShardMap,
+    ShardException
+)
+where
 
-import Data.Bits (shiftL, shiftR)
-import Data.Vector (Vector)
-import qualified Data.Vector as V
-import qualified Data.Text as T
-import Data.Word (Word64)
-import qualified HStream.Store as S
-import Control.Exception (Exception (toException, fromException), SomeException)
-import qualified Z.Data.CBytes as CB
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
-import Data.Typeable (cast)
+import           Control.Concurrent.STM (STM, TMVar, atomically,
+                                         newEmptyTMVarIO, putTMVar, swapTMVar,
+                                         takeTMVar)
+import           Control.Exception      (Exception (fromException, toException),
+                                         SomeException, bracket, throwIO)
+import qualified Crypto.Hash            as CH
+import           Data.Bits              (shiftL, shiftR, (.|.))
+import qualified Data.ByteArray         as BA
+import qualified Data.ByteString        as B
+import           Data.Foldable          (foldl')
+import           Data.Hashable          (Hashable (hash))
+import           Data.Map.Strict        (Map)
+import qualified Data.Map.Strict        as M
+import qualified Data.Text              as T
+import           Data.Typeable          (cast)
+import           Data.Vector            (Vector)
+import qualified Data.Vector            as V
+import           Data.Word              (Word32, Word64)
+import qualified HStream.Logger         as Log
+import qualified HStream.Store          as S
+import qualified Z.Data.CBytes          as CB
 
-type Key = Word64
+type ShardKey = Integer
+
+hashShardKey :: B.ByteString -> Integer
+hashShardKey key =
+  let w8KeyList = BA.unpack (CH.hash key :: CH.Digest CH.MD5)
+   in foldl' (\acc c -> (.|.) (acc `shiftL` 8) (fromIntegral c)) (0 :: Integer) w8KeyList
+
+keyToCBytes :: ShardKey -> CB.CBytes
+keyToCBytes = CB.pack . show
 
 ---------------------------------------------------------------------------------------------------------------
 ---- Shard
 
-data Shard = Shard 
+data Shard = Shard
   { logId    :: S.C_LogID
   , streamId :: S.StreamId
-  , startKey :: Key
-  , endKey   :: Key 
+  , startKey :: ShardKey
+  , endKey   :: ShardKey
+  , epoch    :: Word64
   } deriving(Show)
 
-mkShard :: S.C_LogID -> S.StreamId -> Key -> Key -> Shard
-mkShard logId streamId startKey endKey = Shard {logId, streamId, startKey, endKey}
+mkShard :: S.C_LogID -> S.StreamId -> ShardKey -> ShardKey -> Word64 -> Shard
+mkShard logId streamId startKey endKey epoch = Shard {logId, streamId, startKey, endKey, epoch}
 
-splitShard :: Shard -> Key -> Either ShardException (Shard, Shard)
-splitShard shard@Shard{..} key 
+splitShardByKey :: Shard -> ShardKey -> Either ShardException (Shard, Shard)
+splitShardByKey shard@Shard{..} key
   | startKey > key || endKey < key = Left . ShardException $ CanNotSplit
   | startKey == key = Right (shard, shard)
-    -- split at startKey will return the same shard 
+    -- split at startKey will return the same shard
   | otherwise =
+      let newEpoch = epoch + 2
       -- here key is in (startKey, endKey], so key - 1 will never casue a rewind
-      let s1 = mkShard logId streamId startKey (key - 1)
-          s2 = mkShard logId streamId key endKey
+          s1 = mkShard logId streamId startKey (key - 1) newEpoch
+          s2 = mkShard logId streamId key endKey newEpoch
         in Right (s1, s2)
 
 halfSplit :: Shard -> Either ShardException (Shard, Shard)
-halfSplit shard@Shard{..} 
+halfSplit shard@Shard{..}
   | startKey == endKey = Left . ShardException $ CanNotSplit
-  | otherwise = splitShard shard $ startKey + ((endKey - startKey) `div` 2)
+  | otherwise = splitShardByKey shard $ startKey + ((endKey - startKey) `div` 2)
 
-mergeShard :: Shard -> Shard -> Either ShardException (Shard, Key)
-mergeShard shard1@Shard{logId=logId1, streamId=streamId1, startKey=startKey1, endKey=endKey1} shard2@Shard{logId=logId2, streamId=streamId2, startKey=startKey2, endKey=endKey2} 
+mergeShard :: Shard -> Shard -> Either ShardException (Shard, ShardKey)
+mergeShard shard1@Shard{logId=logId1, streamId=streamId1, startKey=startKey1, endKey=endKey1, epoch=epoch1}
+           shard2@Shard{logId=logId2, streamId=streamId2, startKey=startKey2, endKey=endKey2, epoch=epoch2}
   | logId1 == logId2 = Left . ShardException $ CanNotMerge "cannot merge same shard"
   | endKey1 + 1 /= startKey2 || streamId1 /= streamId2 = Left . ShardException $ CanNotMerge "error shard"
+    -- always let shard1 before shard2, so that after merge, the new shard's key range is [start1, end2],
+    -- and always remove startkey2 from shardMap
   | startKey1 > startKey2 = mergeShard shard2 shard1
-  | otherwise = let newShard = mkShard logId1 streamId1 startKey1 endKey2
+  | otherwise = let newEpoch = max epoch1 epoch2 + 1
+                    newShard = mkShard logId1 streamId1 startKey1 endKey2 newEpoch
                  in Right (newShard, startKey2)
 
 ---------------------------------------------------------------------------------------------------------------
 ---- shardMap
 
-newtype ShardMap = ShardMap { shards :: Map Key Shard }
+type ShardMap = Map ShardKey Shard
 
-getShard :: ShardMap -> Key -> Maybe Shard
-getShard ShardMap{..} key = snd <$> M.lookupLT key shards
+getShard :: ShardMap -> ShardKey -> Maybe Shard
+getShard mp key = snd <$> M.lookupLT key mp
 
-getShard' :: ShardMap -> Key -> Either ShardException Shard
+getShard' :: ShardMap -> ShardKey -> Either ShardException Shard
 getShard' info key = let res = getShard info key
                       in maybeToEither res (ShardException ShardNotExist)
 
-split :: S.LDClient -> ShardMap -> Key -> IO (Either ShardException ShardMap)
-split client info@ShardMap{..} key = case getSplitedShard of
-  Left e -> return $ Left e
-  Right (s1, s2) -> do
-    s1'@Shard{startKey=key1} <- createShard client s1
-    s2'@Shard{startKey=key2} <- createShard client s2
-    let infoTmp = M.insert key1 s1' shards
-        newInfo = M.insert key2 s2' infoTmp
-    return . Right $ info {shards = newInfo}
- where
-   getSplitedShard = getShard' info key >>= flip splitShard key
+getSplitedShard :: ShardMap -> ShardKey -> Either ShardException (Shard, Shard)
+getSplitedShard mp key = getShard' mp key >>= flip splitShardByKey key
 
-merge :: S.LDClient -> ShardMap -> Key -> Key -> IO (Either ShardException ShardMap)
-merge client info@ShardMap{..} key1 key2 = do
-  case getMergedShard of
-    Left e -> return $ Left e
-    Right (s, removedKey) -> do
-      newShard@Shard{startKey} <- createShard client s
-      let infoTmp = M.delete removedKey shards
-          newInfo = M.insert startKey newShard infoTmp
-      return . Right $ info {shards = newInfo}
- where
-   getMergedShard = do
-     s1 <- getShard' info key1
-     s2 <- getShard' info key2
-     mergeShard s1 s2
+getHalfSplitedShard :: ShardMap -> ShardKey -> Either ShardException (Shard, Shard)
+getHalfSplitedShard mp key = getShard' mp key >>= halfSplit
+
+getMergedShard :: ShardMap -> ShardKey -> ShardMap -> ShardKey -> Either ShardException (Shard, ShardKey)
+getMergedShard mp1 key1 mp2 key2 = do
+  s1 <- getShard' mp1 key1
+  s2 <- getShard' mp2 key2
+  mergeShard s1 s2
 
 ---------------------------------------------------------------------------------------------------------------
----- shardMap
+---- sharedShardMap
 
 kNumShardBits :: Int
 kNumShardBits = 4
 
-kNumShards :: Word64
+kNumShards :: Int
 kNumShards = 1 `shiftL` kNumShardBits
 
-data SharedShardMap = SharedShardMap 
-    { shardMaps :: Vector ShardMap
-    }
+-- | A SharedShardMap is a vector with `kNumShards` slots. Each slot stores a ShardMap. for each Shard,
+--   first use `calHash key` to find which slot the ShardMap managing that Shard is stored in, then
+--   you can safely manipulate that ShardMap under the protection of TMVar.
+newtype SharedShardMap = SharedShardMap
+  { shardMaps :: Vector (TMVar ShardMap) }
 
-getShardMap :: SharedShardMap -> Word64 -> ShardMap
-getShardMap SharedShardMap{..} hashValue = (V.!) shardMaps (fromIntegral hashValue)
+mkSharedShardMap :: IO SharedShardMap
+mkSharedShardMap = do shardMaps <- V.replicateM kNumShards newEmptyTMVarIO
+                      return SharedShardMap {shardMaps}
+
+calHash :: ShardKey -> Word32
+calHash key = fromIntegral (hash key) `shiftR` (32 - kNumShardBits)
+
+getShardMap :: SharedShardMap -> Word32 -> STM ShardMap
+getShardMap SharedShardMap{..} hashValue = takeTMVar $ (V.!) shardMaps (fromIntegral hashValue)
+
+putShardMap :: SharedShardMap -> ShardMap -> Word32 -> STM ()
+putShardMap SharedShardMap{..} mp hashValue = putTMVar ((V.!) shardMaps (fromIntegral hashValue)) mp
+
+modifyShardMap :: SharedShardMap -> Word32 -> ShardMap -> STM ShardMap
+modifyShardMap SharedShardMap{..} hashValue = swapTMVar ((V.!) shardMaps (fromIntegral hashValue))
+
+type SplitStrategies = ShardMap -> ShardKey -> Either ShardException (Shard, Shard)
+
+-- | Split Shard with specific ShardKey
+splitByKey :: S.LDClient -> SharedShardMap -> ShardKey -> IO ()
+splitByKey = splitShardInternal getSplitedShard
+
+-- | Splite Shard by half
+splitHalf :: S.LDClient -> SharedShardMap -> ShardKey -> IO ()
+splitHalf = splitShardInternal getHalfSplitedShard
+
+splitShardInternal :: SplitStrategies -> S.LDClient -> SharedShardMap -> ShardKey -> IO ()
+splitShardInternal stratege client sharedMp key = do
+  let hash1 = calHash key
+  bracket
+    (atomically $ getShardMap sharedMp hash1)
+    (\originShardMp -> atomically $ putShardMap sharedMp originShardMp hash1)
+    (\originShardMp -> do
+        case stratege originShardMp key of
+          Left e -> throwIO e
+          Right (s1, s2) -> do
+            s1'@Shard{startKey=key1} <- createShard client s1
+            s2'@Shard{startKey=key2} <- createShard client s2
+            Log.info $ "Split key " <> Log.buildString' key <> " into two new shards: "
+                    <> Log.buildString' (show s1') <> " and "
+                    <> Log.buildString' (show s2')
+
+            let hash1' = calHash key1
+            let hash2' = calHash key2
+            if hash2' == hash1'
+              then do
+                -- After split, two new shard are still managed by same shardMap,
+                let newShardMp = insertMultiShardToMap originShardMp [s1', s2']
+                Log.debug $ "After split " <> Log.buildString' key <> ", "
+                         <> "update shardMp " <> Log.buildString' (show newShardMp)
+                atomically $ putShardMap sharedMp newShardMp hash1'
+              else do
+                -- The two new shards are managed by different shardMap, so they
+                -- need to be updated separately
+                mp2 <- atomically $ getShardMap sharedMp hash2'
+                let newMp1 = M.insert key1 s1' originShardMp
+                    newMp2 = M.insert key2 s2' mp2
+                Log.debug $ "After split " <> Log.buildString' key <> ", "
+                         <> "update shardMp " <> Log.buildString' (show newMp1)
+                         <> " and " <> Log.buildString' (show newMp2)
+                atomically $ do
+                  putShardMap sharedMp newMp1 hash1'
+                  putShardMap sharedMp newMp2 hash2'
+    )
+
+mergeTwoShard :: S.LDClient -> SharedShardMap -> ShardKey -> ShardKey -> IO ()
+mergeTwoShard client mp key1 key2 = do
+  let hash1 = calHash key1
+  let hash2 = calHash key2
+
+  bracket
+    (getShards hash1 hash2)
+    (cleanUp hash1 hash2)
+    (\(shardMp1, shardMp2) -> do
+      case getMergedShard shardMp1 key1 shardMp2 key2 of
+        Left e -> throwIO e
+        Right (s, removedKey) -> do
+          newShard@Shard{startKey} <- createShard client s
+          Log.info $ "Merge " <> Log.buildString' key1 <> " and " <> Log.buildString' key2 <> " into "
+                  <> Log.buildString' (show newShard)
+
+          let (removedShardMp, updateShardMp) = updateShardMap startKey removedKey newShard shardMp1 shardMp2
+          Log.debug $ "After merge " <> Log.buildString' key1 <> " and " <> Log.buildString' key2 <> ","
+                   <> " removedShardMp=" <> Log.buildString' (show removedShardMp)
+                   <> " newShardMp=" <> Log.buildString' (show updateShardMp)
+          atomically $ do
+            putShardMap mp removedShardMp (calHash removedKey)
+            putShardMap mp updateShardMp (calHash startKey)
+    )
+ where
+   getShards hash1 hash2
+     | hash1 == hash2 = do
+        shardMap <- atomically $ getShardMap mp hash1
+        return (shardMap, shardMap)
+     | otherwise = atomically $ do
+         mp1 <- getShardMap mp hash1
+         mp2 <- getShardMap mp hash2
+         return (mp1, mp2)
+
+   cleanUp hash1 hash2 (mp1, mp2)
+     | hash1 == hash2 = atomically $ putShardMap mp mp1 hash1
+     | otherwise = atomically $ do
+         putShardMap mp mp1 hash1
+         putShardMap mp mp2 hash2
+
+   -- key1 -> shardMp1{startKey1, endKey1}, key2 -> shardMp2{startKey2, endKey2}
+   -- getMergedShard always return a new shard with key range [start1, end2], so need to
+   -- remove startKey2 from shardMp2, update startKey1 from shardMp1
+   updateShardMap startKey removedKey newShard shardMp1 shardMp2
+     | startKey == key1 && removedKey == key2 =
+        let rmShard = M.delete removedKey shardMp2
+            upShard = M.insert startKey newShard shardMp1
+        in (rmShard, upShard)
+     | otherwise = updateShardMap removedKey startKey newShard shardMp2 shardMp1
 
 ---------------------------------------------------------------------------------------------------------------
 ---- helper
 
 createShard :: S.LDClient -> Shard -> IO Shard
 createShard client shard@Shard{..} = do
-  newShardId <- S.createStreamPartition client streamId (Just $ getShardName startKey endKey) 
-  return $ shard {logId = newShardId} 
+  let attr = M.fromList [("startKey", keyToCBytes startKey), ("endKey", keyToCBytes endKey), ("epoch", CB.pack . show $ epoch)]
+  newShardId <- S.createStreamPartitionWithExtrAttr client streamId (Just $ getShardName startKey endKey) attr
+  return $ shard {logId = newShardId}
 
-wordToCBytes :: Integral a => a -> CB.CBytes
-wordToCBytes = CB.pack . show . fromIntegral
-
-getShardName :: Key -> Key -> CB.CBytes
-getShardName startKey endKey = "shard-" <> wordToCBytes startKey <> "-" <> wordToCBytes endKey
+getShardName :: ShardKey -> ShardKey -> CB.CBytes
+getShardName startKey endKey = "shard-" <> keyToCBytes startKey <> "-" <> keyToCBytes endKey
 
 maybeToEither :: Maybe a -> e -> Either e a
 maybeToEither mb ep = case mb of
-  Just v -> Right v
+  Just v  -> Right v
   Nothing -> Left ep
+
+insertMultiShardToMap :: ShardMap -> [Shard] -> ShardMap
+insertMultiShardToMap = foldl' (\acc s@Shard{startKey} -> M.insert startKey s acc)
 
 ---------------------------------------------------------------------------------------------------------------
 ---- shardException

--- a/hstream/src/HStream/Server/Shard.hs
+++ b/hstream/src/HStream/Server/Shard.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExistentialQuantification #-} 
+
+module HStream.Server.Shard where
+
+import Data.Bits (shiftL, shiftR)
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import qualified Data.Text as T
+import Data.Word (Word64)
+import qualified HStream.Store as S
+import Control.Exception (Exception (toException, fromException), SomeException)
+import qualified Z.Data.CBytes as CB
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.Typeable (cast)
+
+type Key = Word64
+
+---------------------------------------------------------------------------------------------------------------
+---- Shard
+
+data Shard = Shard 
+  { logId    :: S.C_LogID
+  , streamId :: S.StreamId
+  , startKey :: Key
+  , endKey   :: Key 
+  } deriving(Show)
+
+mkShard :: S.C_LogID -> S.StreamId -> Key -> Key -> Shard
+mkShard logId streamId startKey endKey = Shard {logId, streamId, startKey, endKey}
+
+splitShard :: Shard -> Key -> Either ShardException (Shard, Shard)
+splitShard shard@Shard{..} key 
+  | startKey > key || endKey < key = Left . ShardException $ CanNotSplit
+  | startKey == key = Right (shard, shard)
+    -- split at startKey will return the same shard 
+  | otherwise =
+      -- here key is in (startKey, endKey], so key - 1 will never casue a rewind
+      let s1 = mkShard logId streamId startKey (key - 1)
+          s2 = mkShard logId streamId key endKey
+        in Right (s1, s2)
+
+halfSplit :: Shard -> Either ShardException (Shard, Shard)
+halfSplit shard@Shard{..} 
+  | startKey == endKey = Left . ShardException $ CanNotSplit
+  | otherwise = splitShard shard $ startKey + ((endKey - startKey) `div` 2)
+
+mergeShard :: Shard -> Shard -> Either ShardException (Shard, Key)
+mergeShard shard1@Shard{logId=logId1, streamId=streamId1, startKey=startKey1, endKey=endKey1} shard2@Shard{logId=logId2, streamId=streamId2, startKey=startKey2, endKey=endKey2} 
+  | logId1 == logId2 = Left . ShardException $ CanNotMerge "cannot merge same shard"
+  | endKey1 + 1 /= startKey2 || streamId1 /= streamId2 = Left . ShardException $ CanNotMerge "error shard"
+  | startKey1 > startKey2 = mergeShard shard2 shard1
+  | otherwise = let newShard = mkShard logId1 streamId1 startKey1 endKey2
+                 in Right (newShard, startKey2)
+
+---------------------------------------------------------------------------------------------------------------
+---- shardMap
+
+newtype ShardMap = ShardMap { shards :: Map Key Shard }
+
+getShard :: ShardMap -> Key -> Maybe Shard
+getShard ShardMap{..} key = snd <$> M.lookupLT key shards
+
+getShard' :: ShardMap -> Key -> Either ShardException Shard
+getShard' info key = let res = getShard info key
+                      in maybeToEither res (ShardException ShardNotExist)
+
+split :: S.LDClient -> ShardMap -> Key -> IO (Either ShardException ShardMap)
+split client info@ShardMap{..} key = case getSplitedShard of
+  Left e -> return $ Left e
+  Right (s1, s2) -> do
+    s1'@Shard{startKey=key1} <- createShard client s1
+    s2'@Shard{startKey=key2} <- createShard client s2
+    let infoTmp = M.insert key1 s1' shards
+        newInfo = M.insert key2 s2' infoTmp
+    return . Right $ info {shards = newInfo}
+ where
+   getSplitedShard = getShard' info key >>= flip splitShard key
+
+merge :: S.LDClient -> ShardMap -> Key -> Key -> IO (Either ShardException ShardMap)
+merge client info@ShardMap{..} key1 key2 = do
+  case getMergedShard of
+    Left e -> return $ Left e
+    Right (s, removedKey) -> do
+      newShard@Shard{startKey} <- createShard client s
+      let infoTmp = M.delete removedKey shards
+          newInfo = M.insert startKey newShard infoTmp
+      return . Right $ info {shards = newInfo}
+ where
+   getMergedShard = do
+     s1 <- getShard' info key1
+     s2 <- getShard' info key2
+     mergeShard s1 s2
+
+---------------------------------------------------------------------------------------------------------------
+---- shardMap
+
+kNumShardBits :: Int
+kNumShardBits = 4
+
+kNumShards :: Word64
+kNumShards = 1 `shiftL` kNumShardBits
+
+data SharedShardMap = SharedShardMap 
+    { shardMaps :: Vector ShardMap
+    }
+
+getShardMap :: SharedShardMap -> Word64 -> ShardMap
+getShardMap SharedShardMap{..} hashValue = (V.!) shardMaps (fromIntegral hashValue)
+
+---------------------------------------------------------------------------------------------------------------
+---- helper
+
+createShard :: S.LDClient -> Shard -> IO Shard
+createShard client shard@Shard{..} = do
+  newShardId <- S.createStreamPartition client streamId (Just $ getShardName startKey endKey) 
+  return $ shard {logId = newShardId} 
+
+wordToCBytes :: Integral a => a -> CB.CBytes
+wordToCBytes = CB.pack . show . fromIntegral
+
+getShardName :: Key -> Key -> CB.CBytes
+getShardName startKey endKey = "shard-" <> wordToCBytes startKey <> "-" <> wordToCBytes endKey
+
+maybeToEither :: Maybe a -> e -> Either e a
+maybeToEither mb ep = case mb of
+  Just v -> Right v
+  Nothing -> Left ep
+
+---------------------------------------------------------------------------------------------------------------
+---- shardException
+
+data ShardException = forall e . Exception e => ShardException e
+
+instance Show ShardException where
+  show (ShardException e) = show e
+
+instance Exception ShardException
+
+shardExceptionToException :: Exception e => e -> SomeException
+shardExceptionToException = toException . ShardException
+
+shardExceptionFromException :: Exception e => SomeException -> Maybe e
+shardExceptionFromException x = do
+  fromException @ShardException x >>= cast
+
+data CanNotSplit = CanNotSplit
+  deriving(Show)
+instance Exception CanNotSplit where
+  toException   = shardExceptionToException
+  fromException = shardExceptionFromException
+
+newtype CanNotMerge = CanNotMerge T.Text
+  deriving(Show)
+instance Exception CanNotMerge where
+  toException   = shardExceptionToException
+  fromException = shardExceptionFromException
+
+data ShardNotExist = ShardNotExist
+  deriving(Show)
+instance Exception ShardNotExist where
+  toException   = shardExceptionToException
+  fromException = shardExceptionFromException

--- a/hstream/test/HStream/ShardSpec.hs
+++ b/hstream/test/HStream/ShardSpec.hs
@@ -46,10 +46,10 @@ instance Arbitrary Shard where
     mkShard logId streamId startKey endKey <$> arbitrary
 
 genScopedShardKey :: ShardKey -> ShardKey -> IO ShardKey
-genScopedShardKey startKey endKey = generate $ oneof
-  [ fromIntegral <$> chooseWord64(0, fromIntegral startKey)
-  , fromIntegral <$> chooseWord64(fromIntegral startKey, fromIntegral endKey)
-  , fromIntegral <$> chooseWord64(fromIntegral endKey, maxBound)
+genScopedShardKey startKey endKey = generate $ frequency
+  [ (1, fromIntegral <$> chooseWord64(0, fromIntegral startKey))
+  , (5, fromIntegral <$> chooseWord64(fromIntegral startKey, fromIntegral endKey))
+  , (1, fromIntegral <$> chooseWord64(fromIntegral endKey, maxBound))
   ]
 
 spec :: SpecWith ()

--- a/hstream/test/HStream/ShardSpec.hs
+++ b/hstream/test/HStream/ShardSpec.hs
@@ -12,8 +12,9 @@ import           Data.Maybe            (fromJust)
 import           Data.Word             (Word64)
 import qualified HStream.Logger        as Log
 import           HStream.Server.Shard  (Shard (..), ShardKey, ShardMap,
-                                        getShard, getShardMapIdx, mergeShard,
-                                        mkShard, mkShardMap, splitShardByKey)
+                                        deleteShard, getShard, getShardMapIdx,
+                                        insertShard, mergeShard, mkShard,
+                                        mkShardMap, splitShardByKey)
 import qualified HStream.Store         as S
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
@@ -123,8 +124,8 @@ shardSpec = describe "test manipulate shard" $ do
               (id1, id2) <- generate genOrderPair
               let s1'@Shard{startKey=sk1} = s1 {logId = id1}
               let s2'@Shard{startKey=sk2} = s2 {logId = id2}
-              let mp1 = M.insert sk1 s1' shardMp
-                  mp2 = M.insert sk2 s2' mp1
+              let mp1 = insertShard sk1 s1' shardMp
+                  mp2 = insertShard sk2 s2' mp1
               loop (cnt - 1) mp2
             else do
               shard1@Shard{startKey=sk1, endKey=ek1, logId=id1} <- randomShard shardMp
@@ -141,6 +142,6 @@ shardSpec = describe "test manipulate shard" $ do
                      Log.fatal $ "shardMp = " <> Log.buildString' (show shardMp)
                    isRight res `shouldBe` True
                    let (shard'@Shard{startKey=sk}, removedKey) = head . rights $ [res]
-                   let mp1 = M.delete removedKey shardMp
-                       mp2 = M.insert sk shard'{logId = id1 + id2} mp1
+                   let mp1 = deleteShard removedKey shardMp
+                       mp2 = insertShard sk shard'{logId = id1 + id2} mp1
                    loop (cnt - 1) mp2

--- a/hstream/test/HStream/ShardSpec.hs
+++ b/hstream/test/HStream/ShardSpec.hs
@@ -1,0 +1,146 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module HStream.ShardSpec where
+
+import           Control.Monad         (when)
+import           Data.Either           (isLeft, isRight, rights)
+import           Data.Foldable         (foldl')
+import qualified Data.Map.Strict       as M
+import           Data.Maybe            (fromJust)
+import           Data.Word             (Word64)
+import qualified HStream.Logger        as Log
+import           HStream.Server.Shard  (Shard (..), ShardKey, ShardMap,
+                                        getShard, getShardMapIdx, mergeShard,
+                                        mkShard, mkShardMap, splitShardByKey)
+import qualified HStream.Store         as S
+import           Test.Hspec
+import           Test.Hspec.QuickCheck
+import           Test.QuickCheck
+import           Test.QuickCheck.Gen   (chooseUpTo, chooseWord64)
+import qualified Z.Data.CBytes         as CB
+
+genChar :: Gen Char
+genChar = elements ['a'..'z']
+
+genOrderPair :: Gen (Word64, Word64)
+genOrderPair = do
+  first <- chooseUpTo (maxBound `div` 5000)
+  second <- chooseWord64 (first, maxBound)
+  return (first, second)
+
+instance Arbitrary S.StreamId where
+  arbitrary = do
+    streamName <- CB.pack <$> vectorOf 25 genChar
+    return $ S.mkStreamId S.StreamTypeStream streamName
+
+instance Arbitrary Shard where
+  arbitrary = do
+    (first, second) <- genOrderPair
+    logId           <- arbitrary
+    streamId        <- arbitrary
+    let startKey = fromIntegral first
+        endKey   = fromIntegral second
+    mkShard logId streamId startKey endKey <$> arbitrary
+
+genScopedShardKey :: ShardKey -> ShardKey -> IO ShardKey
+genScopedShardKey startKey endKey = generate $ oneof
+  [ fromIntegral <$> chooseWord64(0, fromIntegral startKey)
+  , fromIntegral <$> chooseWord64(fromIntegral startKey, fromIntegral endKey)
+  , fromIntegral <$> chooseWord64(fromIntegral endKey, maxBound)
+  ]
+
+spec :: SpecWith ()
+spec = describe "HStream.ShardSpec" $ do
+    shardMapIdxSpec
+    shardSpec
+
+shardMapIdxSpec :: SpecWith ()
+shardMapIdxSpec = describe "test get shardMap index" $ do
+  prop "calculate shardMap index" $ do
+    \x -> getShardMapIdx x `shouldSatisfy` (\n -> n >= 0 && n < 16)
+
+shardSpec :: SpecWith ()
+shardSpec = describe "test manipulate shard" $ do
+  prop "Split shard" $ \shard@Shard{..} -> do
+    key <- genScopedShardKey startKey endKey
+    if startKey <= key && endKey >= key
+      then do
+        let res = splitShardByKey shard key
+        isRight res `shouldBe` True
+        let (s1, s2) = head . rights $ [res]
+        (id1, id2) <- generate genOrderPair
+        let s1'@Shard{startKey=startKey1} = s1 {logId = id1}
+        let s2'@Shard{startKey=startKey2, endKey=endKey2} = s2 {logId = id2}
+        let mergeRes = mergeShard s1' s2'
+        when (isLeft mergeRes) $
+          Log.fatal $ "merge shard failed:"
+                   <> " s1= " <> Log.buildString' (show s1')
+                   <> " s2= " <> Log.buildString' (show s2')
+                   <> " mergeRes = " <> Log.buildString' (show mergeRes)
+        isRight mergeRes `shouldBe` True
+        let (Shard{startKey=startKey3, endKey=endKey3}, removedKey) = head . rights $ [mergeRes]
+        removedKey `shouldBe` startKey2
+        startKey3 `shouldBe` startKey1
+        endKey3 `shouldBe` endKey2
+      else do
+        isLeft (splitShardByKey shard key) `shouldBe` True
+
+  prop "Mixed manipulate shard" $ \shard@Shard{startKey=osKey, endKey=oeKey} -> do
+      let shardMp = mkShardMap [(osKey, shard)]
+      newMap <- loop 50 shardMp
+      let shards = map snd $ M.toAscList newMap
+      let Shard{startKey=fsKey, endKey=feKey} = mergeAllShards shards
+      fsKey `shouldBe` osKey
+      feKey `shouldBe` oeKey
+   where
+     randomShard shardMp = do
+       key <- generate (elements . M.keys $ shardMp)
+       case getShard shardMp key of
+         Just shard -> return shard
+         Nothing    -> do
+           Log.fatal $ "randomShard error, key = " <> Log.buildString' (show key) <> ", mp = " <> Log.buildString' (show shardMp)
+           error "get randomShard error"
+
+     randomSplitKey startKey endKey = generate $ fromIntegral <$> chooseWord64 (fromIntegral startKey, fromIntegral endKey)
+
+     mergeAllShards (first : shards) = foldl' (\acc shard -> fst . head . rights $ [mergeShard acc shard]) first shards
+     mergeAllShards [] = error "shards should not empty"
+
+     loop :: Int -> ShardMap -> IO ShardMap
+     loop cnt shardMp
+       | cnt <= 0 = return shardMp
+       | otherwise = do
+          split <- generate $ elements [True, False]
+          if M.size shardMp == 1 || split
+            then do
+              shard'@Shard{..} <- randomShard shardMp
+              splitKey <- randomSplitKey startKey endKey
+              let res = splitShardByKey shard' splitKey
+              isRight res `shouldBe` True
+              let (s1, s2) = head . rights $ [res]
+              (id1, id2) <- generate genOrderPair
+              let s1'@Shard{startKey=sk1} = s1 {logId = id1}
+              let s2'@Shard{startKey=sk2} = s2 {logId = id2}
+              let mp1 = M.insert sk1 s1' shardMp
+                  mp2 = M.insert sk2 s2' mp1
+              loop (cnt - 1) mp2
+            else do
+              shard1@Shard{startKey=sk1, endKey=ek1, logId=id1} <- randomShard shardMp
+              let shard2@Shard{startKey=sk2, logId=id2} = fromJust $ getShard shardMp (ek1 + 1)
+              if sk1 == sk2
+                 then loop cnt shardMp
+                 else do
+                   let res = mergeShard shard1 shard2
+                   when (isLeft res) $ do
+                     Log.fatal $ "merge shard failed:"
+                              <> " s1= " <> Log.buildString' (show shard1)
+                              <> " s2= " <> Log.buildString' (show shard2)
+                              <> " mergeRes = " <> Log.buildString' (show res)
+                     Log.fatal $ "shardMp = " <> Log.buildString' (show shardMp)
+                   isRight res `shouldBe` True
+                   let (shard'@Shard{startKey=sk}, removedKey) = head . rights $ [res]
+                   let mp1 = M.delete removedKey shardMp
+                       mp2 = M.insert sk shard'{logId = id1 + id2} mp1
+                   loop (cnt - 1) mp2


### PR DESCRIPTION
# PR Description

## Type of change

- [x] New feature 

### Summary of the change and which issue is fixed

Main changes: 
- `ShardKey` is an integer that represents a value in the space of consecutive keys. Users can use the MD5 algorithm to map the actual business key to a value in the key space.
- `Shard` indicates a Shard of a stream. Each time a `Shard` can be split into two shards, or two adjacent shards can be merged into one shard.
- `ShardMap` maps Starkey to a specific Shard. `ShardMap` allows the user to locate the shard to which the specified ShardKey belongs.
- `SharedShardMap` allocates 16 slots, each of which has a `ShardMap` protected by TMVar. User finds the corresponding `ShardMap` in the `SharedShardMap` by the ShardKey first, and then can perform other operations safely

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
