### PR TITLE
bug fixed: a shard can be assigned to an invalid consumer

### DIFF
--- a/hstream/src/HStream/Server/Core/Subscription.hs
+++ b/hstream/src/HStream/Server/Core/Subscription.hs
@@ -950,6 +950,9 @@ invalidConsumer SubscribeContext{subAssignment = Assignment{..}, ..} consumer = 
               <- foldM unbindShardWithConsumer (idleShards, shardMap) works
             writeTVar waitingReassignedShards shardsNeedAssign
             writeTVar shard2Consumer newShardMap
+            modifyTVar consumerWorkloads
+              (Set.filter (\ConsumerWorkload{..} ->
+                              cwConsumerName /= consumer))
         let newConsumerCtx = HM.delete consumer ccs
         writeTVar subConsumerContexts newConsumerCtx
       else pure ()


### PR DESCRIPTION
This can cause severe inconsistency between `subConsumerContexts` and `shard2Consumer`, which leads to a forever read-send-retry loop. The appearance of the bug is one or more message is lost. 