### PR TITLE
hstream app: add `-e --execute` for sql

### DIFF
--- a/hstream/app/client.hs
+++ b/hstream/app/client.hs
@@ -12,9 +12,10 @@ import           Control.Concurrent               (forkFinally, myThreadId,
                                                    newMVar, readMVar,
                                                    threadDelay, throwTo)
 import           Control.Exception                (finally, handle)
-import           Control.Monad                    (forever, void, (>=>))
+import           Control.Monad                    (forever, void, when, (>=>))
 import           Control.Monad.IO.Class           (liftIO)
 import           Data.Char                        (toUpper)
+import qualified Data.Char                        as Char
 import qualified Data.List                        as L
 import qualified Data.Map                         as M
 import           Data.Maybe                       (maybeToList)
@@ -113,7 +114,9 @@ hstreamSQL CliConnOpts{..} HStreamSqlOpts{_updateInterval = updateInterval, _ret
   void $ describeCluster ctx addr
   case statement of
     Nothing        -> showHStream *> interactiveSQLApp ctx
-    Just statement -> commandExec ctx statement
+    Just statement -> do
+      when (Char.isSpace `all` statement) $ do putStrLn "Empty statement" *> exitFailure
+      commandExec ctx statement
   where
     showHStream = putStrLn [r|
       __  _________________  _________    __  ___

--- a/hstream/app/client.hs
+++ b/hstream/app/client.hs
@@ -111,9 +111,9 @@ hstreamSQL CliConnOpts{..} HStreamSqlOpts{_updateInterval = updateInterval, _ret
     Nothing -> errorWithoutStackTrace "Connection timed out. Please check the server URI and try again."
     Just _  -> pure ()
   void $ describeCluster ctx addr
-  if statement == ""
-    then showHStream *> interactiveSQLApp ctx
-    else commandExec ctx statement
+  case statement of
+    Nothing -> showHStream *> interactiveSQLApp ctx
+    Just statement -> commandExec ctx statement
   where
     showHStream = putStrLn [r|
       __  _________________  _________    __  ___

--- a/hstream/app/client.hs
+++ b/hstream/app/client.hs
@@ -112,7 +112,7 @@ hstreamSQL CliConnOpts{..} HStreamSqlOpts{_updateInterval = updateInterval, _ret
     Just _  -> pure ()
   void $ describeCluster ctx addr
   case statement of
-    Nothing -> showHStream *> interactiveSQLApp ctx
+    Nothing        -> showHStream *> interactiveSQLApp ctx
     Just statement -> commandExec ctx statement
   where
     showHStream = putStrLn [r|

--- a/hstream/src/HStream/Client/Types.hs
+++ b/hstream/src/HStream/Client/Types.hs
@@ -35,12 +35,14 @@ data HStreamSqlContext = HStreamSqlContext
 data HStreamSqlOpts = HStreamSqlOpts
   { _updateInterval :: Int
   , _retryTimeout   :: Int
+  , _execute        :: String
   }
 
 hstreamSqlOptsParser :: O.Parser HStreamSqlOpts
 hstreamSqlOptsParser = HStreamSqlOpts
-  <$> O.option O.auto (O.long "update-interval" <> O.metavar "INT" <> O.showDefault <> O.value 30 <> O.help "interval to update available servers in seconds")
-  <*> O.option O.auto (O.long "retry-timeout" <> O.metavar "INT" <> O.showDefault <> O.value 60 <> O.help "timeout to retry connecting to a server in seconds")
+  <$> O.option O.auto (O.long "update-interval"        <> O.metavar "INT" <> O.showDefault <> O.value 30 <> O.help "interval to update available servers in seconds")
+  <*> O.option O.auto (O.long "retry-timeout"          <> O.metavar "INT" <> O.showDefault <> O.value 60 <> O.help "timeout to retry connecting to a server in seconds")
+  <*> O.option O.str  (O.long "execute" <> O.short 'e' <> O.metavar "STRING"               <> O.value "" <> O.help "execute the statement and quit")
 
 data HStreamNodes
   = HStreamNodesList

--- a/hstream/src/HStream/Client/Types.hs
+++ b/hstream/src/HStream/Client/Types.hs
@@ -35,14 +35,14 @@ data HStreamSqlContext = HStreamSqlContext
 data HStreamSqlOpts = HStreamSqlOpts
   { _updateInterval :: Int
   , _retryTimeout   :: Int
-  , _execute        :: String
+  , _execute        :: Maybe String
   }
 
 hstreamSqlOptsParser :: O.Parser HStreamSqlOpts
 hstreamSqlOptsParser = HStreamSqlOpts
-  <$> O.option O.auto (O.long "update-interval"        <> O.metavar "INT" <> O.showDefault <> O.value 30 <> O.help "interval to update available servers in seconds")
-  <*> O.option O.auto (O.long "retry-timeout"          <> O.metavar "INT" <> O.showDefault <> O.value 60 <> O.help "timeout to retry connecting to a server in seconds")
-  <*> O.option O.str  (O.long "execute" <> O.short 'e' <> O.metavar "STRING"               <> O.value "" <> O.help "execute the statement and quit")
+  <$> O.option O.auto (O.long "update-interval" <> O.metavar "INT" <> O.showDefault <> O.value 30 <> O.help "interval to update available servers in seconds")
+  <*> O.option O.auto (O.long "retry-timeout"   <> O.metavar "INT" <> O.showDefault <> O.value 60 <> O.help "timeout to retry connecting to a server in seconds")
+  <*> (O.optional . O.option O.str) (O.long "execute" <> O.short 'e' <> O.metavar "STRING" <> O.help "execute the statement and quit")
 
 data HStreamNodes
   = HStreamNodesList


### PR DESCRIPTION
# PR Description

## Type of change


- [x] New feature 
- [x] Documentation updates required

### Summary of the change and which issue is fixed

Main changes: add `-e --execute` for sql

```sh
I have no name!@inductive:~/re/repl/hstream/hstream$ cabal run hstream -- sql -e 'create stream sss;'
Up to date
sss
I have no name!@inductive:~/re/repl/hstream/hstream$ cabal run hstream -- sql -e 'create stream ssss;'
Up to date
ssss
I have no name!@inductive:~/re/repl/hstream/hstream$ cabal run hstream -- sql -e 'insert into stream s (x, y) values (32, 20);'
Up to date
Parse exception at <line 1,column 13>: syntax error before `STREAM'.
I have no name!@inductive:~/re/repl/hstream/hstream$ cabal run hstream -- sql -e 'insert into  s (x, y) values (32, 20);'

I have no name!@inductive:~/re/repl/hstream/hstream$ cabal run hstream -- sql --execute 'insert into  s (x, y) values (32, 20);'
Up to date
Done.
I have no name!@inductive:~/re/repl/hstream/hstream$ cabal run hstream -- sql --execute='insert into  s (x, y) values (32, 20);'
Up to date
Done.
I have no name!@inductive:~/re/repl/hstream/hstream$ cabal run hstream -- sql --execute="insert into  s (x, y) values (32, 20);"
Up to date
Done.
I have no name!@inductive:~/re/repl/hstream/hstream$ cabal run hstream -- sql --execute="select * from s emit changes;"
Up to date
^CTerminated

```

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
