### PR TITLE
cli: enter multi-line mode when throwing EOF

### DIFF
--- a/hstream-sql/src/HStream/SQL/Exception.hs
+++ b/hstream-sql/src/HStream/SQL/Exception.hs
@@ -91,13 +91,11 @@ throwSQLException exceptionType exceptionPos exceptionMsg =
 
 isEOF :: SomeSQLException -> Bool
 isEOF xs =
-  case x of
-    Right _ -> False
-    Left e  -> case e of
-      ParseException info ->
-        let SomeSQLExceptionInfo _ msg _ = info in
-          msg == "syntax error at end of file"
-      _ -> False
+  case xs of
+    ParseException info ->
+      let SomeSQLExceptionInfo _ msg _ = info in
+        msg == "syntax error at end of file"
+    _ -> False
 
 --------------------------------------------------------------------------------
 data SomeRuntimeException = SomeRuntimeException

--- a/hstream/app/client.hs
+++ b/hstream/app/client.hs
@@ -274,9 +274,10 @@ readToSQL acc = do
       Left err ->
         if isEOF err
             then do
-              H.outputStr "| "
-              line <- liftIO $ T.getLine
-              readToSQL $ acc <> " " <> line
+              line <- H.getInputLine "| "
+              case line of
+                Nothing   -> pure . Just $ T.unpack acc
+                Just line -> readToSQL $ acc <> " " <> T.pack line
             else do
               H.outputStrLn . formatSomeSQLException $ err
               pure Nothing

--- a/hstream/app/client.hs
+++ b/hstream/app/client.hs
@@ -5,13 +5,14 @@
 {-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Main where
 
 import           Control.Concurrent               (forkFinally, myThreadId,
                                                    newMVar, readMVar,
                                                    threadDelay, throwTo)
-import           Control.Exception                (finally, handle)
+import           Control.Exception                (finally, handle, throw, try)
 import           Control.Monad                    (forever, void, when, (>=>))
 import           Control.Monad.IO.Class           (liftIO)
 import           Data.Aeson                       as Aeson
@@ -79,7 +80,8 @@ import           HStream.SQL                      (HStreamPlan (..),
                                                    parseAndRefine,
                                                    pattern ConnectorWritePlan)
 import           HStream.SQL.Exception            (SomeSQLException,
-                                                   formatSomeSQLException)
+                                                   formatSomeSQLException,
+                                                   isEOF)
 import           HStream.ThirdParty.Protobuf      (Empty (Empty))
 import           HStream.Utils                    (HStreamClientApi,
                                                    SocketAddr (..),
@@ -121,7 +123,7 @@ hstreamSQL CliConnOpts{..} HStreamSqlOpts{_updateInterval = updateInterval, .. }
     Nothing        -> showHStream *> interactiveSQLApp ctx
     Just statement -> do
       when (Char.isSpace `all` statement) $ do putStrLn "Empty statement" *> exitFailure
-      commandExec False ctx statement
+      commandExec ctx statement
   where
     showHStream = putStrLn [r|
       __  _________________  _________    __  ___
@@ -207,10 +209,12 @@ interactiveSQLApp ctx@HStreamSqlContext{..} = do
         Nothing -> pure ()
         Just str
           | take 1 (words str) == [":q"] -> pure ()
-          | otherwise -> liftIO (commandExec True ctx str) >> loop
+          | otherwise -> do
+              str <- readToSQL $ T.pack str
+              liftIO (commandExec ctx str) >> loop
 
-commandExec :: HStreamSqlContext -> Bool -> String -> IO ()
-commandExec ctx@HStreamSqlContext{..} interactive xs = case words xs of
+commandExec :: HStreamSqlContext -> String -> IO ()
+commandExec ctx@HStreamSqlContext{..} xs = case words xs of
   [] -> return ()
 
   -- The Following commands are for testing only
@@ -227,45 +231,52 @@ commandExec ctx@HStreamSqlContext{..} interactive xs = case words xs of
   ":help":x:_ -> case M.lookup (map toUpper x) helpInfos of Just infos -> putStrLn infos; Nothing -> pure ()
 
   (_:_)       -> liftIO $ handle (\(e :: SomeSQLException) -> putStrLn . formatSomeSQLException $ e) $ do
-    x <- try @SomeSQLException $ (parseAndRefine . T.pack) xs
+    rSQL <- parseAndRefine $ T.pack xs
+    case rSQL of
+      RQSelect{} -> runActionWithGrpc ctx (\api -> sqlStreamAction api (T.pack xs))
+      RQCreate (RCreateAs stream _ rOptions) ->
+        execute_ ctx $ createStreamBySelect stream (rRepFactor rOptions) xs
+      rSql' -> hstreamCodegen rSql' >>= \case
+        CreatePlan sName rFac
+          -> execute_ ctx $ createStream sName rFac
+        ShowPlan showObj
+          -> executeShowPlan ctx showObj
+        TerminatePlan termSel
+          -> execute_ ctx $ terminateQueries termSel
+        DropPlan checkIfExists dropObj
+          -> execute_ ctx $ dropAction checkIfExists dropObj
+        InsertPlan sName insertType payload
+          -> do
+            result <- execute ctx $ listShards sName
+            case result of
+              Just (API.ListShardsResponse shards) -> do
+                let API.Shard{..}:_ = V.toList shards
+                execute_ ctx $ insertIntoStream sName shardShardId insertType payload
+              Nothing -> return ()
+        ConnectorWritePlan name -> do
+          addr <- readMVar currentServer
+          lookupConnector ctx addr name >>= \case
+            Nothing -> putStrLn "lookupConnector failed"
+            Just node -> do
+              withGRPCClient (mkGRPCClientConf (serverNodeToSocketAddr node))
+                (hstreamApiClient >=> \api -> sqlAction api (T.pack xs))
+        _ -> do
+          addr <- readMVar currentServer
+          withGRPCClient (mkGRPCClientConf addr)
+            (hstreamApiClient >=> \api -> sqlAction api (T.pack xs))
+
+readToSQL :: T.Text -> H.InputT IO String
+readToSQL acc = do
+    x <- liftIO $ try @SomeSQLException $ parseAndRefine acc
     case x of
       Left err ->
-        if interactive && isEOF err
-          then putStr "| " >> getLine >>= \line -> commandExec ctx True (xs <> line)
-          else throw err
-      Right ok ->
-        case ok of
-          RQSelect{} -> runActionWithGrpc ctx (\api -> sqlStreamAction api (T.pack xs))
-          RQCreate (RCreateAs stream _ rOptions) ->
-            execute_ ctx $ createStreamBySelect stream (rRepFactor rOptions) xs
-          rSql' -> hstreamCodegen rSql' >>= \case
-            CreatePlan sName rFac
-              -> execute_ ctx $ createStream sName rFac
-            ShowPlan showObj
-              -> executeShowPlan ctx showObj
-            TerminatePlan termSel
-              -> execute_ ctx $ terminateQueries termSel
-            DropPlan checkIfExists dropObj
-              -> execute_ ctx $ dropAction checkIfExists dropObj
-            InsertPlan sName insertType payload
-              -> do
-                result <- execute ctx $ listShards sName
-                case result of
-                  Just (API.ListShardsResponse shards) -> do
-                    let API.Shard{..}:_ = V.toList shards
-                    execute_ ctx $ insertIntoStream sName shardShardId insertType payload
-                  Nothing -> return ()
-            ConnectorWritePlan name -> do
-              addr <- readMVar currentServer
-              lookupConnector ctx addr name >>= \case
-                Nothing -> putStrLn "lookupConnector failed"
-                Just node -> do
-                  withGRPCClient (mkGRPCClientConf (serverNodeToSocketAddr node))
-                    (hstreamApiClient >=> \api -> sqlAction api (T.pack xs))
-            _ -> do
-              addr <- readMVar currentServer
-              withGRPCClient (mkGRPCClientConf addr)
-                (hstreamApiClient >=> \api -> sqlAction api (T.pack xs))
+        if isEOF err
+            then do
+              H.outputStr "| "
+              line <- liftIO $ T.getLine
+              readToSQL $ acc <> " " <> line
+            else throw err
+      Right _ -> pure $ T.unpack acc
 
 sqlStreamAction :: HStreamClientApi -> T.Text -> IO ()
 sqlStreamAction HStreamApi{..} sql = do

--- a/hstream/app/server.hs
+++ b/hstream/app/server.hs
@@ -14,7 +14,7 @@ import           Control.Concurrent.STM           (TVar, atomically, retry,
                                                    writeTVar)
 import           Control.Monad                    (forM_, void, when)
 import           Data.ByteString                  (ByteString)
-import qualified Data.ByteString.Short            as BS (toShort)
+import qualified Data.ByteString.Short            as BS
 import qualified Data.Map                         as Map
 import qualified Data.Text                        as T
 import           Data.Text.Encoding               (encodeUtf8)


### PR DESCRIPTION
# PR Description

## Type of change

- [x] New feature 

### Summary of the change and which issue is fixed

Main changes:

```
> select
| *
| from
| s
| emit
| changes
| ;
^CTerminated
> show streams
| ;
+----------------------+---------+----------------+-------------+
| Stream Name          | Replica | Retention Time | Shard Count |
+----------------------+---------+----------------+-------------+
| juqlTVOFCAvGfHHMIPqE | 1       | 0sec           | 1           |
+----------------------+---------+----------------+-------------+
| ZSHhwSTZAiACReNLwkfQ | 1       | 0sec           | 1           |
+----------------------+---------+----------------+-------------+
| aKyGZDCkdeUmFIBamDtW | 1       | 0sec           | 1           |
+----------------------+---------+----------------+-------------+
| TgDNyMLAxEsbkKVMEuGx | 1       | 0sec           | 1           |
+----------------------+---------+----------------+-------------+
| DPpClhNohpBXbYYTQYjZ | 1       | 0sec           | 1           |
+----------------------+---------+----------------+-------------+
| IuAYjTuvkjdwEURatdcj | 1       | 0sec           | 1           |
+----------------------+---------+----------------+-------------+
| WHvdvbOSNAYZNRGBqhSK | 1       | 0sec           | 1           |
+----------------------+---------+----------------+-------------+
| s                    | 3       | 0sec           | 1           |
+----------------------+---------+----------------+-------------+
> show stream
Parse exception at <line 1,column 6>: syntax error before `STREAM'.
> 
```

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
