### PR TITLE
hstream-sql: err msg for missing `;`

### DIFF
--- a/hstream-sql/src/HStream/SQL/AST.hs
+++ b/hstream-sql/src/HStream/SQL/AST.hs
@@ -8,7 +8,6 @@ module HStream.SQL.AST where
 import qualified Data.Aeson            as Aeson
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BSC
-import           Data.Functor
 import qualified Data.HashMap.Strict   as HM
 import           Data.Kind             (Type)
 import           Data.Text             (Text)

--- a/hstream-sql/src/HStream/SQL/Exception.hs
+++ b/hstream-sql/src/HStream/SQL/Exception.hs
@@ -98,7 +98,7 @@ isEOF xs =
   case xs of
     ParseException info ->
       let SomeSQLExceptionInfo _ msg _ = info in
-        msg == "syntax error at end of file"
+        msg == eofErrMsg
     _ -> False
 
 eofErrMsg :: String

--- a/hstream-sql/src/HStream/SQL/Exception.hs
+++ b/hstream-sql/src/HStream/SQL/Exception.hs
@@ -101,6 +101,9 @@ isEOF xs =
         msg == "syntax error at end of file"
     _ -> False
 
+eofErrMsg :: String
+eofErrMsg = "syntax error at end of file"
+
 --------------------------------------------------------------------------------
 data SomeRuntimeException = SomeRuntimeException
   { runtimeExceptionMessage   :: String

--- a/hstream-sql/src/HStream/SQL/Exception.hs
+++ b/hstream-sql/src/HStream/SQL/Exception.hs
@@ -53,7 +53,11 @@ formatParseExceptionInfo SomeSQLExceptionInfo{..} =
   case words sqlExceptionMessage of
     "syntax" : "error" : "at" : "line" : x : "column" : y : ss ->
       "at <line " ++ x ++ "column " ++ y ++ ">: syntax error " ++ unwords ss ++ "."
-    _ -> posInfo ++ sqlExceptionMessage ++ "."
+    _ ->
+      let detailedSqlExceptionMessage = if sqlExceptionMessage /= eofErrMsg
+            then sqlExceptionMessage
+            else sqlExceptionMessage <> ": expected a \";\" at the end of a statement"
+      in posInfo ++ detailedSqlExceptionMessage ++ "."
   where
     posInfo = case sqlExceptionPosition of
         Just (l,c) -> "at <line " ++ show l ++ ", column " ++ show c ++ ">"


### PR DESCRIPTION
# PR Description

## Type of change

- [x] New feature 

### Summary of the change and which issue is fixed

Main changes:

```
> select * from s emit changes
| 
| 
Parse exception syntax error at end of file: expected a ";" at the end of a statement.
> select * from s emit changes;
^CTerminated
> 
I have no name!@inductive:~/re-fk/hstream/hstream$ cabal run hstream -- sql -e 'select * from s emit changes'
Up to date
Parse exception syntax error at end of file: expected a ";" at the end of a statement.
```

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
