### PR TITLE
cli: history and bug fix

### DIFF
--- a/hstream/app/client.hs
+++ b/hstream/app/client.hs
@@ -212,8 +212,9 @@ interactiveSQLApp ctx@HStreamSqlContext{..} historyFile = do
       RL.getInputLine "> " >>= \case
         Nothing -> pure ()
         Just str
+          | take 1 (words str)             == []     -> loop
           | take 1 (words str)             == [":q"] -> pure ()
-          | (take 1 (words str)) !! 0 !! 0 == ':'    -> liftIO (commandExec ctx str) >> loop
+          | (take 1 $ words str) !! 0 !! 0 == ':'    -> liftIO (commandExec ctx str) >> loop
           | otherwise -> do
               str <- readToSQL $ T.pack str
               case str of

--- a/hstream/app/client.hs
+++ b/hstream/app/client.hs
@@ -34,7 +34,8 @@ import           Network.GRPC.HighLevel.Generated (ClientError (ClientIOError),
                                                    withGRPCClient)
 import           Network.GRPC.LowLevel.Call       (clientCallCancel)
 import qualified Options.Applicative              as O
-import qualified System.Console.Haskeline         as H
+import qualified System.Console.Haskeline         as RL
+import qualified System.Console.Haskeline.History as RL
 import           System.Exit                      (exitFailure)
 import           System.Posix                     (Handler (Catch),
                                                    installHandler,
@@ -120,7 +121,7 @@ hstreamSQL CliConnOpts{..} HStreamSqlOpts{_updateInterval = updateInterval, .. }
     Just _  -> pure ()
   void $ describeCluster ctx addr
   case _execute of
-    Nothing        -> showHStream *> interactiveSQLApp ctx
+    Nothing        -> showHStream *> interactiveSQLApp ctx _historyFile
     Just statement -> do
       when (Char.isSpace `all` statement) $ do putStrLn "Empty statement" *> exitFailure
       commandExec ctx statement
@@ -190,30 +191,37 @@ getNodes CliConnOpts{..} =
 
 -- FIXME: Currently, every new command will create a new connection to a server,
 -- and this needs to be optimized. This could be done with a grpc client pool.
-interactiveSQLApp :: HStreamSqlContext -> IO ()
-interactiveSQLApp ctx@HStreamSqlContext{..} = do
+interactiveSQLApp :: HStreamSqlContext -> Maybe FilePath -> IO ()
+interactiveSQLApp ctx@HStreamSqlContext{..} historyFile = do
   putStrLn helpInfo
   tid <- myThreadId
   void $ forkFinally maintainAvailableNodes (\case Left err -> throwTo tid err; _ -> return ())
-  H.runInputT H.defaultSettings loop
+  RL.runInputT settings loop
   where
+    settings :: RL.Settings IO
+    settings = RL.Settings RL.noCompletion historyFile False
+
     maintainAvailableNodes = forever $ do
       readMVar availableServers >>= \case
         []     -> return ()
         node:_ -> void $ describeCluster ctx node
       threadDelay $ updateInterval * 1000 * 1000
 
-    loop :: H.InputT IO ()
-    loop = H.withInterrupt . H.handleInterrupt loop $ do
-      H.getInputLine "> " >>= \case
+    loop :: RL.InputT IO ()
+    loop = RL.withInterrupt . RL.handleInterrupt loop $ do
+      RL.getInputLine "> " >>= \case
         Nothing -> pure ()
         Just str
-          | take 1 (words str) == [":q"] -> pure ()
+          | take 1 (words str)             == [":q"] -> pure ()
+          | (take 1 (words str)) !! 0 !! 0 == ':'    -> liftIO (commandExec ctx str) >> loop
           | otherwise -> do
               str <- readToSQL $ T.pack str
               case str of
                 Nothing  -> loop
-                Just str -> liftIO (commandExec ctx str) >> loop
+                Just str -> do
+                  RL.getHistory >>= RL.putHistory . RL.addHistoryUnlessConsecutiveDupe str
+                  liftIO (commandExec ctx str)
+                  loop
 
 commandExec :: HStreamSqlContext -> String -> IO ()
 commandExec ctx@HStreamSqlContext{..} xs = case words xs of
@@ -267,19 +275,19 @@ commandExec ctx@HStreamSqlContext{..} xs = case words xs of
           withGRPCClient (mkGRPCClientConf addr)
             (hstreamApiClient >=> \api -> sqlAction api (T.pack xs))
 
-readToSQL :: T.Text -> H.InputT IO (Maybe String)
+readToSQL :: T.Text -> RL.InputT IO (Maybe String)
 readToSQL acc = do
     x <- liftIO $ try @SomeSQLException $ parseAndRefine acc
     case x of
       Left err ->
         if isEOF err
             then do
-              line <- H.getInputLine "| "
+              line <- RL.getInputLine "| "
               case line of
                 Nothing   -> pure . Just $ T.unpack acc
                 Just line -> readToSQL $ acc <> " " <> T.pack line
             else do
-              H.outputStrLn . formatSomeSQLException $ err
+              RL.outputStrLn . formatSomeSQLException $ err
               pure Nothing
       Right _ -> pure . Just $ T.unpack acc
 

--- a/hstream/src/HStream/Client/Types.hs
+++ b/hstream/src/HStream/Client/Types.hs
@@ -36,6 +36,7 @@ data HStreamSqlOpts = HStreamSqlOpts
   { _updateInterval :: Int
   , _retryTimeout   :: Int
   , _execute        :: Maybe String
+  , _historyFile    :: Maybe String
   }
 
 hstreamSqlOptsParser :: O.Parser HStreamSqlOpts
@@ -43,6 +44,7 @@ hstreamSqlOptsParser = HStreamSqlOpts
   <$> O.option O.auto (O.long "update-interval" <> O.metavar "INT" <> O.showDefault <> O.value 30 <> O.help "interval to update available servers in seconds")
   <*> O.option O.auto (O.long "retry-timeout"   <> O.metavar "INT" <> O.showDefault <> O.value 60 <> O.help "timeout to retry connecting to a server in seconds")
   <*> (O.optional . O.option O.str) (O.long "execute" <> O.short 'e' <> O.metavar "STRING" <> O.help "execute the statement and quit")
+  <*> (O.optional . O.option O.str) (O.long "history-file" <> O.metavar "STRING" <> O.help "history file path to write interactively executed statements")
 
 data HStreamNodes
   = HStreamNodesList


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 
- [x] New feature 

### Summary of the change and which issue is fixed

Main changes:

- fix a bug that admin command does not parse
- add history and opts for cli

```
I have no name!@inductive:~/hstream/hstream$ cabal run hstream -- sql --history-file=$PWD/.hstream_history
> create stream sss;
sss
> create
| stream
| ssss;
ssss
> select * from s emit changes;
^CTerminated
> show streams;

```

```
show streams;
select * from s emit changes;
create stream ssss;
create stream sss;
create stream ss;
```

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
