### PR TITLE
fix `max-record-size` option validation

### DIFF
--- a/hstream/src/HStream/Server/Config.hs
+++ b/hstream/src/HStream/Server/Config.hs
@@ -198,7 +198,7 @@ parseJSONToOptions CliOptions {..} obj = do
   -- TODO: For the max_record_size to work properly, we should also tell user
   -- to set payload size for gRPC and LD.
   _maxRecordSize    <- nodeCfgObj .:? "max-record-size" .!= 1048576
-  when (_maxRecordSize < 0 && _maxRecordSize > 104876)
+  when (_maxRecordSize < 0 && _maxRecordSize > 1048576)
     $ errorWithoutStackTrace "max-record-size has to be a positive number less than 1MB"
 
   let _serverID           = fromMaybe nodeId _serverID_


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Documentation updates required

### Summary of the change and which issue is fixed

Main changes: fix a probable typo in `max-record-size` option validation

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
