### PR TITLE
add check-running subcommand for hstream nodes 

### DIFF
--- a/hstream/src/HStream/Client/Types.hs
+++ b/hstream/src/HStream/Client/Types.hs
@@ -5,6 +5,7 @@ import           Data.ByteString               (ByteString)
 import           Network.GRPC.HighLevel.Client (ClientSSLConfig)
 import qualified Options.Applicative           as O
 
+import           Data.Word                     (Word32)
 import           HStream.Admin.Server.Types    (StreamCommand, streamCmdParser)
 import           HStream.Server.Types          (ServerID)
 import           HStream.Utils                 (SocketAddr)
@@ -55,12 +56,15 @@ hstreamSqlOptsParser = HStreamSqlOpts
 data HStreamNodes
   = HStreamNodesList
   | HStreamNodesStatus (Maybe ServerID)
+  | HStreamNodesCheck (Maybe Word32)
 
 hstreamNodesParser :: O.Parser HStreamNodes
 hstreamNodesParser = O.hsubparser
-  (  O.command "list" (O.info (pure HStreamNodesList) (O.progDesc "List all running nodes in the cluster"))
-  <> O.command "status" (O.info (HStreamNodesStatus <$> (O.optional . O.option O.auto) (O.long "id" <> O.help "Specify the id of the node"))
-                                (O.progDesc "Show the status of nodes specified, if not specified show the status of all nodes"))
+  (  O.command "list"     (O.info (pure HStreamNodesList) (O.progDesc "List all running nodes in the cluster"))
+  <> O.command "status"   (O.info (HStreamNodesStatus <$> (O.optional . O.option O.auto) (O.long "id" <> O.help "Specify the id of the node"))
+                                  (O.progDesc "Show the status of nodes specified, if not specified show the status of all nodes"))
+  <> O.command "check-running" (O.info (HStreamNodesCheck <$> (O.optional . O.option O.auto) (O.long "minimum-running" <> O.short 'n' <> O.help "Specify minimum number of the nodes") )
+                                       (O.progDesc "Check if all nodes in the the cluster are running, and the number of nodes is at least as specified"))
   )
 
 newtype HStreamInitOpts = HStreamInitOpts { _timeoutSec :: Int }


### PR DESCRIPTION
usage：
```
> hstream nodes check-running -n 3
All nodes in the cluster are running.
```