### PR TITLE
 add server `advertised-listeners` options 

### DIFF
--- a/hstream/src/HStream/Server/Config.hs
+++ b/hstream/src/HStream/Server/Config.hs
@@ -13,6 +13,7 @@ module HStream.Server.Config
   , MetaStoreAddr(..)
   , parseJSONToOptions
   , readProtocol
+  , parseHostPorts
   ) where
 
 import           Control.Exception              (throwIO)

--- a/hstream/src/HStream/Server/Config.hs
+++ b/hstream/src/HStream/Server/Config.hs
@@ -31,6 +31,7 @@ import qualified Data.Text                      as T
 import qualified Data.Text                      as Text
 import           Data.Text.Encoding             (encodeUtf8)
 import           Data.Vector                    (Vector)
+import qualified Data.Vector                    as V
 import           Data.Word                      (Word16, Word32)
 import           Data.Yaml                      as Y (Object,
                                                       ParseException (..),
@@ -39,8 +40,7 @@ import           Data.Yaml                      as Y (Object,
                                                       (.:?))
 import           Options.Applicative            as O (Alternative (many, (<|>)),
                                                       CompletionResult (execCompletion),
-                                                      Parser,
-                                                      ParserResult (CompletionInvoked, Failure, Success),
+                                                      Parser, ParserResult (..),
                                                       auto, defaultPrefs,
                                                       execParserPure, flag,
                                                       fullDesc, help, helper,
@@ -64,7 +64,6 @@ import qualified HStream.Logger                 as Log
 import qualified HStream.Server.HStreamInternal as SAI
 import           HStream.Store                  (Compression (..))
 import qualified HStream.Store.Logger           as Log
-
 
 -------------------------------------------------------------------------------
 
@@ -139,31 +138,32 @@ getConfig = do
 -------------------------------------------------------------------------------
 
 data CliOptions = CliOptions
-  { _configPath          :: !String
-  , _serverHost_         :: !(Maybe CBytes)
-  , _serverPort_         :: !(Maybe Word16)
-  , _serverAddress_      :: !(Maybe String)
-  , _serverInternalPort_ :: !(Maybe Word16)
-  , _serverID_           :: !(Maybe Word32)
-  , _serverLogLevel_     :: !(Maybe Log.Level)
-  , _serverLogWithColor_ :: !Bool
-  , _compression_        :: !(Maybe Compression)
-  , _metaStore_          :: !(Maybe MetaStoreAddr)
-  , _seedNodes_          :: !(Maybe Text)
+  { _configPath                 :: !String
+  , _serverHost_                :: !(Maybe CBytes)
+  , _serverPort_                :: !(Maybe Word16)
+  , _serverAddress_             :: !(Maybe String)
+  , _serverAdvertisedListeners_ :: !AdvertisedListeners
+  , _serverInternalPort_        :: !(Maybe Word16)
+  , _serverID_                  :: !(Maybe Word32)
+  , _serverLogLevel_            :: !(Maybe Log.Level)
+  , _serverLogWithColor_        :: !Bool
+  , _compression_               :: !(Maybe Compression)
+  , _metaStore_                 :: !(Maybe MetaStoreAddr)
+  , _seedNodes_                 :: !(Maybe Text)
 
-  , _enableTls_          :: !Bool
-  , _tlsKeyPath_         :: !(Maybe String)
-  , _tlsCertPath_        :: !(Maybe String)
-  , _tlsCaPath_          :: !(Maybe String)
+  , _enableTls_                 :: !Bool
+  , _tlsKeyPath_                :: !(Maybe String)
+  , _tlsCertPath_               :: !(Maybe String)
+  , _tlsCaPath_                 :: !(Maybe String)
 
-  , _ldAdminHost_        :: !(Maybe ByteString)
-  , _ldAdminPort_        :: !(Maybe Int)
-  , _ldLogLevel_         :: !(Maybe Log.LDLogLevel)
-  , _storeConfigPath     :: !CBytes
+  , _ldAdminHost_               :: !(Maybe ByteString)
+  , _ldAdminPort_               :: !(Maybe Int)
+  , _ldLogLevel_                :: !(Maybe Log.LDLogLevel)
+  , _storeConfigPath            :: !CBytes
 
-  , _ioTasksPath_        :: !(Maybe Text)
-  , _ioTasksNetwork_     :: !(Maybe Text)
-  , _ioConnectorImages_  :: ![Text]
+  , _ioTasksPath_               :: !(Maybe Text)
+  , _ioTasksNetwork_            :: !(Maybe Text)
+  , _ioConnectorImages_         :: ![Text]
   }
   deriving Show
 
@@ -176,6 +176,7 @@ cliOptionsParser = do
   _configPath          <- configPath
   _serverHost_         <- optional serverHost
   _serverAddress_      <- optional serverAddress
+  _serverAdvertisedListeners_ <- Map.fromList <$> many advertisedListeners
   _serverPort_         <- optional serverPort
   _serverInternalPort_ <- optional serverInternalPort
   _seedNodes_          <- optional seedNodes
@@ -200,12 +201,11 @@ cliOptionsParser = do
 parseJSONToOptions :: CliOptions -> Y.Object -> Y.Parser ServerOpts
 parseJSONToOptions CliOptions {..} obj = do
   nodeCfgObj  <- obj .: "hserver"
-
   nodeId              <- nodeCfgObj .:  "id"
   nodePort            <- nodeCfgObj .:? "port" .!= 6570
   nodeAddress         <- nodeCfgObj .:  "address"
   nodeInternalPort    <- nodeCfgObj .:? "internal-port" .!= 6571
-  advertisedListeners <- nodeCfgObj .:? "advertised-listeners"
+  nodeAdvertisedListeners <- nodeCfgObj .:? "advertised-listeners" .!= mempty
 
   nodeMetaStore     <- parseMetaStoreAddr <$> nodeCfgObj .:  "metastore-uri" :: Y.Parser MetaStoreAddr
   serverCompression <- readWithErrLog "compression" <$> nodeCfgObj .:? "compression" .!= "lz4"
@@ -217,17 +217,17 @@ parseJSONToOptions CliOptions {..} obj = do
   when (_maxRecordSize < 0 && _maxRecordSize > 1048576)
     $ errorWithoutStackTrace "max-record-size has to be a positive number less than 1MB"
 
-  let _serverID           = fromMaybe nodeId _serverID_
-  let _serverHost         = fromMaybe "0.0.0.0" _serverHost_
-  let _serverPort         = fromMaybe nodePort _serverPort_
-  let _serverInternalPort = fromMaybe nodeInternalPort _serverInternalPort_
-  let _serverAddress      = fromMaybe nodeAddress _serverAddress_
-  let _serverAdvertisedListeners = fromMaybe Map.empty advertisedListeners
+  let !_serverID           = fromMaybe nodeId _serverID_
+  let !_serverHost         = fromMaybe "0.0.0.0" _serverHost_
+  let !_serverAddress      = fromMaybe nodeAddress _serverAddress_
+  let !_serverPort         = fromMaybe nodePort _serverPort_
+  let !_serverInternalPort = fromMaybe nodeInternalPort _serverInternalPort_
+  let !_serverAdvertisedListeners = Map.union _serverAdvertisedListeners_ nodeAdvertisedListeners
 
-  let _metaStore          = fromMaybe nodeMetaStore _metaStore_
-  let _serverLogLevel     = fromMaybe (readWithErrLog "log-level" nodeLogLevel) _serverLogLevel_
-  let _serverLogWithColor = nodeLogWithColor || _serverLogWithColor_
-  let _compression        = fromMaybe serverCompression _compression_
+  let !_metaStore          = fromMaybe nodeMetaStore _metaStore_
+  let !_serverLogLevel     = fromMaybe (readWithErrLog "log-level" nodeLogLevel) _serverLogLevel_
+  let !_serverLogWithColor = nodeLogWithColor || _serverLogWithColor_
+  let !_compression        = fromMaybe serverCompression _compression_
 
   -- Cluster Option
   seeds <- flip fromMaybe _seedNodes_ <$> (nodeCfgObj .: "seed-nodes")
@@ -255,22 +255,22 @@ parseJSONToOptions CliOptions {..} obj = do
   _ldAdminSendTimeout <- sAdminCfgObj .:? "send-timeout" .!= 5000
   _ldAdminRecvTimeout <- sAdminCfgObj .:? "recv-timeout" .!= 5000
 
-  let _ldAdminHost    = fromMaybe storeAdminHost _ldAdminHost_
-  let _ldAdminPort    = fromMaybe storeAdminPort _ldAdminPort_
-  let _ldConfigPath   = _storeConfigPath
-  let _ldLogLevel     = fromMaybe storeLogLevel  _ldLogLevel_
-  let _topicRepFactor = 1
-  let _ckpRepFactor   = 3
+  let !_ldAdminHost    = fromMaybe storeAdminHost _ldAdminHost_
+  let !_ldAdminPort    = fromMaybe storeAdminPort _ldAdminPort_
+  let !_ldConfigPath   = _storeConfigPath
+  let !_ldLogLevel     = fromMaybe storeLogLevel  _ldLogLevel_
+  let !_topicRepFactor = 1
+  let !_ckpRepFactor   = 3
 
   -- TLS config
   nodeEnableTls   <- nodeCfgObj .:? "enable-tls" .!= False
   nodeTlsKeyPath  <- nodeCfgObj .:? "tls-key-path"
   nodeTlsCertPath <- nodeCfgObj .:? "tls-cert-path"
   nodeTlsCaPath   <- nodeCfgObj .:? "tls-ca-path"
-  let _enableTls   = _enableTls_ || nodeEnableTls
-      _tlsKeyPath  = _tlsKeyPath_  <|> nodeTlsKeyPath
-      _tlsCertPath = _tlsCertPath_ <|> nodeTlsCertPath
-      _tlsCaPath   = _tlsCaPath_   <|> nodeTlsCaPath
+  let !_enableTls   = _enableTls_ || nodeEnableTls
+      !_tlsKeyPath  = _tlsKeyPath_  <|> nodeTlsKeyPath
+      !_tlsCertPath = _tlsCertPath_ <|> nodeTlsCertPath
+      !_tlsCaPath   = _tlsCaPath_   <|> nodeTlsCaPath
       !_tlsConfig  = case (_enableTls, _tlsKeyPath, _tlsCertPath) of
         (False, _, _) -> Nothing
         (_, Nothing, _) -> errorWithoutStackTrace "enable-tls=true, but tls-key-path is empty"
@@ -299,7 +299,7 @@ parseJSONToOptions CliOptions {..} obj = do
         (nodeSourceImages, nodeSinkImages) _ioConnectorImages_
   let optTasksPath = fromMaybe nodeIOTasksPath _ioTasksPath_
       optTasksNetwork = fromMaybe nodeIOTasksNetwork _ioTasksNetwork_
-      _ioOptions = IO.IOOptions {..}
+      !_ioOptions = IO.IOOptions {..}
   return ServerOpts {..}
 
 -------------------------------------------------------------------------------
@@ -340,6 +340,17 @@ serverID = option auto
   $ long "server-id"
   <> metavar "UINT32"
   <> help "ID of the hstream server node"
+
+-- | Format:  <listener_key>:hstream://<address>:<port>
+-- Equivalent to the following in configuration file:
+-- <listener_key>:
+--  address: <host>
+--  port: <port>
+advertisedListeners :: O.Parser (Text, Vector SAI.Listener)
+advertisedListeners = option (maybeReader (either (const Nothing) Just . AP.parseOnly listenerP . T.pack))
+  $  long "advertised-listeners"
+  <> metavar "LISTENER"
+  <> help "advertised listener, in format <listener_key>:hstream://<address>:<port>. e.g. private:hstream://127.0.0.1:6580"
 
 seedNodes :: O.Parser Text
 seedNodes = strOption
@@ -466,6 +477,16 @@ metaStoreP = do
   AP.string "://"
   ip <- AP.takeText
   return (scheme, ip)
+
+listenerP :: AP.Parser (Text, Vector SAI.Listener)
+listenerP = do
+  key <- AP.takeTill (== ':')
+  AP.string ":hstream://"
+  address <- AP.takeTill (== ':')
+  AP.char ':'
+  port <- AP.decimal
+  AP.endOfInput
+  return (key, V.singleton SAI.Listener { listenerAddress = address, listenerPort = port})
 
 -- TODO: Haskell libraries does not support the case where multiple auths exist
 -- case parseURI str of

--- a/hstream/test/HStream/ConfigSpec.hs
+++ b/hstream/test/HStream/ConfigSpec.hs
@@ -163,6 +163,7 @@ emptyCliOptions = CliOptions {
   , _serverHost_         = Nothing
   , _serverPort_         = Nothing
   , _serverAddress_      = Nothing
+  , _serverAdvertisedListeners_ = mempty
   , _serverInternalPort_ = Nothing
   , _serverID_           = Nothing
   , _serverLogLevel_     = Nothing

--- a/hstream/test/HStream/ConfigSpec.hs
+++ b/hstream/test/HStream/ConfigSpec.hs
@@ -2,16 +2,25 @@
 
 module HStream.ConfigSpec where
 
+import           Control.Applicative            ((<|>))
+import           Control.Exception              (SomeException (SomeException),
+                                                 evaluate, try)
+import           Data.Aeson.Encode.Pretty       (encodePretty)
+import           Data.Bifunctor                 (second)
 import           Data.ByteString                (ByteString)
+import qualified Data.ByteString.Lazy           as BSL
 import qualified Data.HashMap.Strict            as HM
 import qualified Data.Map.Strict                as M
+import qualified Data.Map.Strict                as Map
+import           Data.Maybe                     (fromMaybe, isJust)
 import           Data.Text                      (Text)
 import qualified Data.Text                      as T
 import           Data.Text.Encoding             (decodeUtf8, encodeUtf8)
 import           Data.Yaml                      (ToJSON (..), Value (..),
                                                  decodeThrow, encode, object,
                                                  parseEither, (.=))
-import           Test.Hspec                     (Spec, describe, it, shouldBe)
+import           Test.Hspec                     (Spec, anyException, describe,
+                                                 it, shouldBe, shouldThrow)
 import           Test.Hspec.QuickCheck          (prop)
 import           Test.QuickCheck                (Arbitrary, Gen, choose,
                                                  elements, listOf, listOf1)
@@ -27,7 +36,7 @@ import           HStream.IO.Types               (IOOptions (..))
 import           HStream.Server.Config          (CliOptions (..),
                                                  MetaStoreAddr (..),
                                                  ServerOpts (..),
-                                                 TlsConfig (..),
+                                                 TlsConfig (..), parseHostPorts,
                                                  parseJSONToOptions,
                                                  readProtocol)
 import           HStream.Server.HStreamInternal
@@ -50,6 +59,18 @@ spec = describe "HStream.ConfigSpec" $ do
       obj <- decodeThrow yaml
       -- putStrLn $ T.unpack $ decodeUtf8 $ BSL.toStrict $ encodePretty obj
       parseEither (parseJSONToOptions emptyCliOptions) obj `shouldBe` Right x
+
+    prop "Cli options override configuration files" $ \(serverOpts, cliOptions) -> do
+      let yaml = encode $ toJSON serverOpts
+      -- putStrLn $ T.unpack $ decodeUtf8 yaml
+      obj <- decodeThrow yaml
+      -- putStrLn $ T.unpack $ decodeUtf8 $ BSL.toStrict $ encodePretty obj
+      -- print cliOptions
+      try (evaluate $ updateServerOptsWithCliOpts cliOptions serverOpts) >>= \case
+        Left (_ :: SomeException) -> do
+          evaluate (parseEither (parseJSONToOptions cliOptions) obj) `shouldThrow` anyException
+        Right success -> parseEither (parseJSONToOptions cliOptions) obj `shouldBe` Right success
+
 
 defaultConfig :: ServerOpts
 defaultConfig = ServerOpts
@@ -198,7 +219,7 @@ instance Arbitrary ServerOpts where
     _serverPort                <- fromIntegral <$> portGen
     _serverAddress             <- addressGen
     _serverInternalPort        <- fromIntegral <$> portGen
-    _serverAdvertisedListeners <- M.fromList <$> listOf5 ((,) <$> (T.pack <$> nameGen) <*> arbitrary)
+    _serverAdvertisedListeners <- M.fromList <$> listOf5' ((,) <$> (T.pack <$> nameGen) <*> arbitrary)
     _metaStore                 <- arbitrary
     let _ldConfigPath   = "/data/store/logdevice.conf"
     let _topicRepFactor = 1
@@ -219,6 +240,33 @@ instance Arbitrary ServerOpts where
     _gossipOpts                <- arbitrary
     _ioOptions                 <- arbitrary
     pure ServerOpts{..}
+
+instance Arbitrary CliOptions where
+  arbitrary = do
+    let _configPath = ""
+    _serverHost_         <- genMaybe $ CB.pack <$> addressGen
+    _serverPort_         <- genMaybe $ fromIntegral <$> portGen
+    _serverAddress_      <- genMaybe addressGen
+    _serverAdvertisedListeners_ <- arbitrary
+    _serverInternalPort_ <- genMaybe $ fromIntegral <$> portGen
+    _serverID_           <- arbitrary
+    _serverLogLevel_     <- genMaybe $ read <$> logLevelGen
+    _serverLogWithColor_ <- arbitrary
+    _compression_        <- arbitrary
+    _metaStore_          <- arbitrary
+    _seedNodes_          <- genMaybe seedNodesStringGen
+    _enableTls_          <- arbitrary
+    _tlsKeyPath_         <- genMaybe pathGen
+    _tlsCertPath_        <- genMaybe pathGen
+    _tlsCaPath_          <- genMaybe pathGen
+    _ldAdminHost_        <- genMaybe $ encodeUtf8 . T.pack <$> addressGen
+    _ldAdminPort_        <- genMaybe portGen
+    _ldLogLevel_         <- genMaybe $ read <$> ldLogLevelGen
+    _storeConfigPath     <- CB.pack <$> pathGen
+    _ioTasksPath_        <- genMaybe $ T.pack <$> pathGen
+    _ioTasksNetwork_     <- genMaybe $ T.pack <$> nameGen
+    _ioConnectorImages_  <- listOf5' $ T.pack <$> connectorImageCliOptGen
+    pure CliOptions{..}
 
 instance Arbitrary Listener where
   arbitrary = do
@@ -315,3 +363,65 @@ listOf5 x = resize 5 (listOf x)
 
 listOf5' :: Gen a -> Gen [a]
 listOf5' x = resize 5 (listOf1 x)
+
+connectorImageCliOptGen :: Gen String
+connectorImageCliOptGen = do
+  cType <- elements ["source", "sink"]
+  cName <- nameGen
+  iName <- nameGen
+  pure $ unwords [cType, cName, iName]
+
+genMaybe :: Gen a -> Gen (Maybe a)
+genMaybe gen = oneof [pure Nothing, Just <$> gen]
+
+seedNodesStringGen :: Gen Text
+seedNodesStringGen = T.intercalate ", " <$> listOf5' (T.pack <$> uriGen)
+
+updateServerOptsWithCliOpts :: CliOptions -> ServerOpts -> ServerOpts
+updateServerOptsWithCliOpts CliOptions {..} x@ServerOpts{..} = x {
+    _serverHost = fromMaybe _serverHost _serverHost_
+  , _serverPort = port
+  , _serverInternalPort = fromMaybe _serverInternalPort _serverInternalPort_
+  , _serverAddress = fromMaybe _serverAddress _serverAddress_
+  , _serverAdvertisedListeners = Map.union _serverAdvertisedListeners_ _serverAdvertisedListeners
+  , _serverID = fromMaybe _serverID _serverID_
+  , _metaStore = fromMaybe _metaStore _metaStore_
+  , _ldConfigPath = _storeConfigPath
+  , _compression = fromMaybe _compression _compression_
+  , _tlsConfig = _tlsConfig_
+  , _serverLogLevel = fromMaybe _serverLogLevel _serverLogLevel_
+  , _serverLogWithColor = _serverLogWithColor || _serverLogWithColor_
+  , _seedNodes = fromMaybe _seedNodes $ parseCliSeeds =<< _seedNodes_
+  , _ldAdminHost = fromMaybe _ldAdminHost _ldAdminHost_
+  , _ldAdminPort = fromMaybe _ldAdminPort _ldAdminPort_
+  , _ldLogLevel = fromMaybe _ldLogLevel _ldLogLevel_
+  , _ioOptions = _ioOptions_}
+  where
+    port = fromMaybe _serverPort _serverPort_
+    updateSeedsPort = second $ fromMaybe (fromIntegral port)
+    parseCliSeeds = either (const Nothing) (Just . (updateSeedsPort <$>)) . parseHostPorts
+
+    _tlsConfig_  = case (_enableTls_ || isJust _tlsConfig, _tlsKeyPath_ <|> keyPath <$> _tlsConfig,  _tlsCertPath_ <|> certPath <$> _tlsConfig ) of
+        (False, _, _) -> Nothing
+        (_, Nothing, _) -> errorWithoutStackTrace "enable-tls=true, but tls-key-path is empty"
+        (_, _, Nothing) -> errorWithoutStackTrace "enable-tls=true, but tls-cert-path is empty"
+        (_, Just kp, Just cp) -> Just $ TlsConfig kp cp (_tlsCaPath_ <|> (caPath =<< _tlsConfig) )
+
+    (ssi,ski) = foldr
+        (\img (ss, sk) -> do
+          -- "source mysql IMAGE" -> ("source" "mysq" "IMAGE")
+          let parseImage = toThreeTuple . T.words
+              toThreeTuple [a, b, c] = pure (a, b, c)
+          (typ, ct, di) <- parseImage img
+          case T.toLower typ of
+            "source" -> (HM.insert ct di ss, sk)
+            "sink"   -> (ss, HM.insert ct di sk)
+            _        -> (ss, sk)
+        )
+        (optSourceImages _ioOptions, optSinkImages _ioOptions) _ioConnectorImages_
+    _ioOptions_ = IOOptions {
+            optTasksNetwork = fromMaybe (optTasksNetwork _ioOptions) _ioTasksNetwork_
+          , optTasksPath = fromMaybe (optTasksPath _ioOptions) _ioTasksPath_
+          , optSourceImages = ssi
+          , optSinkImages = ski
+          }


### PR DESCRIPTION
Format: ` <listener_key>:hstream://<address>:<port>`

Equivalent to the following in the configuration file:

```
 <listener_key>:
   - address: <address>
     port: <port>
```

Usage:
```
hstream-server --advertised-listeners public:hstream://192.168.1.190:6580 --advertised-listeners public:hstream://192.168.1.190:6590 
```
