### PR TITLE
fix: retry when resend reader read null records

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -3,8 +3,11 @@ cradle:
     - path: "common/."
       component: "lib:hstream-common"
 
-    - path: "common/api/gen-hs"
-      component: "lib:hstream-common"
+    - path: "common/base/."
+      component: "lib:hstream-common-base"
+
+    - path: "common/api/."
+      component: "lib:hstream-api-hs"
 
     - path: "common/test"
       component: "hstream-common:test:hstream-common-test"
@@ -297,7 +300,7 @@ cradle:
     - path: "hstream-sql/test"
       component: "hstream-sql:test:hstream-sql-test"
 
-    - path: "hstream-store/./"
+    - path: "hstream-store/."
       component: "lib:hstream-store"
 
     - path: "hstream-store/test"

--- a/hstream-store/HStream/Store/Internal/LogDevice/Reader.hs
+++ b/hstream-store/HStream/Store/Internal/LogDevice/Reader.hs
@@ -117,6 +117,9 @@ startReadingFromCheckpoint reader logid untilSeq =
     E.throwStreamErrorIfNotOK . warnSlow $
       ld_checkpointed_reader_start_reading_from_ckp ptr logid untilSeq
 
+  -- Note: The exception NOTFOUND means the log is not being read, either because
+  -- readerStartReading() was never called (or readerStopReading() was
+  -- called), or because `until` LSN was reached
 readerStopReading :: LDReader -> C_LogID -> IO ()
 readerStopReading reader logid =
   withForeignPtr reader $ \ptr -> void $


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes: 
- set default 10 ms timeout for reader
- retry when reader read get null records
- fix hie.yaml

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
