### PR TITLE
set timeout for ldCkpReader to avoid stuck forcing delete subscription

### DIFF
--- a/hstream/src/HStream/Server/Core/Subscription.hs
+++ b/hstream/src/HStream/Server/Core/Subscription.hs
@@ -356,6 +356,8 @@ doSubInit ServerContext{..} subId = do
       -- Ideally, if the subscription has no data to deliver, ldCkpReader should block on the read call. However, in the current implementation,
       -- a subscription forcing deletion operation requires that the sendRecords loop should `not` be blocked, otherwise the forcing deletion
       -- would be blocked because the delete precondition cannot be met. So set a 1s timeout for ldCkpReader
+      -- 
+      -- TODO: Also consider calling stopReading to stop the reader while force deleting instead of setting timeout.
       S.ckpReaderSetTimeout ldCkpReader 1000
       S.ckpReaderSetWaitOnlyWhenNoData ldCkpReader
       -- create a ldReader for rereading unacked records


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 


### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
