### PR TITLE
[skip ci] chore: add `shell.nix` and enable `make all` on non-FHS distro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,8 @@ BNFC = bnfc
 PROTO_COMPILE = protoc
 PROTO_COMPILE_HS = ~/.cabal/bin/compile-proto-file_hstream
 
-ifeq ($(shell test -e /etc/NIXOS; echo $$?), 1)
-	PROTO_CPP_PLUGIN ?= /usr/local/bin/grpc_cpp_plugin
-else
-	PROTO_CPP_PLUGIN ?= $(shell which grpc_cpp_plugin 2>/dev/null)
-endif
+PROTO_CPP_PLUGIN ?= /usr/local/bin/grpc_cpp_plugin
+PROTOC_INCLUDE_DIR ?= /usr/local/include
 
 THRIFT_COMPILE = thrift-compiler
 thrift::
@@ -41,20 +38,20 @@ grpc-hs-deps::
 
 grpc-hs: grpc-hs-deps
 	($(PROTO_COMPILE_HS) \
-		--includeDir /usr/local/include \
+		--includeDir $(PROTOC_INCLUDE_DIR) \
 		--proto google/protobuf/struct.proto \
 		--out common/api/gen-hs)
 	($(PROTO_COMPILE_HS) \
-		--includeDir /usr/local/include \
+		--includeDir $(PROTOC_INCLUDE_DIR) \
 		--proto google/protobuf/empty.proto \
 		--out common/api/gen-hs)
 	(cd common/api/protos && $(PROTO_COMPILE_HS) \
-		--includeDir /usr/local/include \
+		--includeDir $(PROTOC_INCLUDE_DIR) \
 		--includeDir . \
 		--proto HStream/Server/HStreamApi.proto \
 		--out ../gen-hs)
 	(cd common/api/protos && $(PROTO_COMPILE_HS) \
-		--includeDir /usr/local/include \
+		--includeDir $(PROTOC_INCLUDE_DIR) \
 		--includeDir . \
 		--proto HStream/Server/HStreamInternal.proto \
 		--out ../gen-hs)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ ENGINE_VERSION ?= v1
 BNFC = bnfc
 PROTO_COMPILE = protoc
 PROTO_COMPILE_HS = ~/.cabal/bin/compile-proto-file_hstream
-PROTO_CPP_PLUGIN ?= /usr/local/bin/grpc_cpp_plugin
+
+ifeq ($(shell test -e /etc/NIXOS; echo $$?), 1)
+	PROTO_CPP_PLUGIN ?= /usr/local/bin/grpc_cpp_plugin
+else
+	PROTO_CPP_PLUGIN ?= $(shell which grpc_cpp_plugin 2>/dev/null)
+endif
 
 THRIFT_COMPILE = thrift-compiler
 thrift::

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,14 @@ in
           with ghcPkgs; [
             haskell-language-server
             cabal-install
+
+            BNFC
+            alex
+            happy
           ]))
     ];
+    shellHook = ''
+      export PROTO_CPP_PLUGIN="$(which grpc_cpp_plugin)"
+      export PROTOC_INCLUDE_DIR="$(dirname $(dirname $(which protoc)))/include"
+    '';
   }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+let
+  pkgs =
+    import (fetchTarball
+      "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz") {};
+in
+  pkgs.mkShell {
+    packages = with pkgs; [
+      protobuf
+      grpc
+
+      (haskell.packages.ghc927.ghcWithPackages
+        (ghcPkgs:
+          with ghcPkgs; [
+            haskell-language-server
+            cabal-install
+          ]))
+    ];
+  }


### PR DESCRIPTION
# PR Description

## Type of change

- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change
- [ ] Documentation updates required

### Summary of the change and which issue is fixed

Main changes: enable build on NixOS

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
