### PR TITLE
sql: deny unquoted dash in ident

### DIFF
--- a/hstream-sql/etc/SQL-v1.cf
+++ b/hstream-sql/etc/SQL-v1.cf
@@ -12,14 +12,13 @@ PDouble.  PNDouble ::= "+" Double ;
 IPDouble. PNDouble ::=     Double ;
 NDouble.  PNDouble ::= "-" Double ;
 
-token HyphenIdent letter (letter | digit | '_' | '\'' | '-')* ;
 token SString '\'' char+ '\'' ;
 token QuotedRaw '`' (char - ["`"])+ '`' ;
 
-ColumnIdentNormal. ColumnIdent ::= HyphenIdent ;
-ColumnIdentRaw.    ColumnIdent ::= QuotedRaw;
+ColumnIdentNormal. ColumnIdent ::= Ident     ;
+ColumnIdentRaw.    ColumnIdent ::= QuotedRaw ;
 
-HIdentNormal. HIdent ::= HyphenIdent ;
+HIdentNormal. HIdent ::= Ident     ;
 HIdentRaw.    HIdent ::= QuotedRaw ;
 --------------------------------------------------------------------------------
 

--- a/hstream-sql/etc/SQL-v2.cf
+++ b/hstream-sql/etc/SQL-v2.cf
@@ -12,14 +12,13 @@ PDouble.  PNDouble ::= "+" Double ;
 IPDouble. PNDouble ::=     Double ;
 NDouble.  PNDouble ::= "-" Double ;
 
-token HyphenIdent letter (letter | digit | '_' | '\'' | '-')* ;
 token SString '\'' char+ '\'' ;
 token QuotedRaw '`' (char - ["`"])+ '`' ;
 
-ColumnIdentNormal. ColumnIdent ::= HyphenIdent ;
-ColumnIdentRaw.    ColumnIdent ::= QuotedRaw;
+ColumnIdentNormal. ColumnIdent ::= Ident     ;
+ColumnIdentRaw.    ColumnIdent ::= QuotedRaw ;
 
-HIdentNormal. HIdent ::= HyphenIdent ;
+HIdentNormal. HIdent ::= Ident     ;
 HIdentRaw.    HIdent ::= QuotedRaw ;
 --------------------------------------------------------------------------------
 

--- a/hstream-sql/src/HStream/SQL/Extra.hs
+++ b/hstream-sql/src/HStream/SQL/Extra.hs
@@ -26,12 +26,12 @@ extractPNDouble (IPDouble _ n) = n
 extractPNDouble (NDouble  _ n) = (-n)
 
 extractColumnIdent :: ColumnIdent -> Text
-extractColumnIdent (ColumnIdentNormal _ (HyphenIdent text)) = text
+extractColumnIdent (ColumnIdentNormal _ (Ident text)) = text
 extractColumnIdent (ColumnIdentRaw _ (QuotedRaw text')) =
   Text.tail . Text.init $ text'
 
 extractHIdent :: HIdent -> Text
-extractHIdent (HIdentNormal _ (HyphenIdent text)) = text
+extractHIdent (HIdentNormal _ (Ident text)) = text
 extractHIdent (HIdentRaw _ (QuotedRaw text')) =
   Text.tail . Text.init $ text'
 

--- a/hstream-sql/src/HStream/SQL/Internal/Validate.hs
+++ b/hstream-sql/src/HStream/SQL/Internal/Validate.hs
@@ -58,14 +58,14 @@ instance Validate PNDouble where
 instance Validate SString where
   validate = return
 
-instance Validate HyphenIdent where
+instance Validate Ident where
   validate = return
 
 instance Validate QuotedRaw where
   validate = return
 
 instance Validate HIdent where
-  validate ident@(HIdentNormal pos (HyphenIdent text)) = do
+  validate ident@(HIdentNormal pos (Ident text)) = do
     unless (Text.length text <= maxIdentifierLength) (Left $ buildSQLException ParseException pos ("The length of an identifier should be equal to or less than " <> show maxIdentifierLength))
     return ident
   validate ident@(HIdentRaw pos (QuotedRaw text')) = do
@@ -83,7 +83,7 @@ instance Validate HIdent where
                    ) True (Text.tail ts)
 
 instance Validate ColumnIdent where
-  validate ident@(ColumnIdentNormal pos (HyphenIdent text)) = do
+  validate ident@(ColumnIdentNormal pos (Ident text)) = do
     unless (Text.length text <= maxIdentifierLength) (Left $ buildSQLException ParseException pos ("The length of an identifier should be equal to or less than " <> show maxIdentifierLength))
     return ident
   validate ident@(ColumnIdentRaw pos (QuotedRaw text')) = do

--- a/hstream-sql/test/HStream/SQL/ParseRefineSpec.hs
+++ b/hstream-sql/test/HStream/SQL/ParseRefineSpec.hs
@@ -73,22 +73,3 @@ spec = describe "Create" $ do
     parseAndRefine "DROP STREAM foo IF EXISTS;"    `shouldReturn` RQDrop (RDropIf RDropStream    "foo")
     parseAndRefine "DROP VIEW foo;"                `shouldReturn` RQDrop (RDrop   RDropView      "foo")
     parseAndRefine "DROP VIEW foo IF EXISTS;"      `shouldReturn` RQDrop (RDropIf RDropView      "foo")
-
-  it "HS-3148" $ do
-    let ret0 = RQPushSelect (RSelect (RSel [RSelectItemProject (RExprAccessJson "c->>\"season_id\"" JOpLongArrow (RExprCol "c" Nothing "c") (RExprConst "\"season_id\"" (ConstantText "season_id"))) Nothing]) (RFrom (RTableRefSimple "production_changes" Nothing)) RWhereEmpty RGroupByEmpty RHavingEmpty)
-    parseAndRefine "select c->> \"season_id\" from production_changes EMIT CHANGES;"  `shouldReturn` ret0
-    parseAndRefine "select c ->> \"season_id\" from production_changes EMIT CHANGES;" `shouldReturn` ret0
-    parseAndRefine "select c->>\"season_id\" from production_changes EMIT CHANGES;"   `shouldReturn` ret0
-    parseAndRefine "select c->> \"season_id\" from production_changes EMIT CHANGES;"  `shouldReturn` ret0
-
-    let ret1 = RQPushSelect (RSelect (RSel [RSelectItemProject (RExprAccessJson "c->\"season_id\"" JOpArrow (RExprCol "c" Nothing "c") (RExprConst "\"season_id\"" (ConstantText "season_id"))) Nothing]) (RFrom (RTableRefSimple "production_changes" Nothing)) RWhereEmpty RGroupByEmpty RHavingEmpty)
-    parseAndRefine "select c ->\"season_id\" from production_changes EMIT CHANGES;"  `shouldReturn` ret1
-    parseAndRefine "select c -> \"season_id\" from production_changes EMIT CHANGES;" `shouldReturn` ret1
-    parseAndRefine "select c->\"season_id\" from production_changes EMIT CHANGES;"   `shouldReturn` ret1
-    parseAndRefine "select c-> \"season_id\" from production_changes EMIT CHANGES;"  `shouldReturn` ret1
-
-  it "HS-3332" $ do
-    parseAndRefine "select a-b, a, b from s emit changes;" `shouldReturn` RQPushSelect (RSelect (RSel [RSelectItemProject (RExprBinOp "a-b" OpSub (RExprCol "a" Nothing "a") (RExprCol "b" Nothing "b")) Nothing,RSelectItemProject (RExprCol "a" Nothing "a") Nothing,RSelectItemProject (RExprCol "b" Nothing "b") Nothing]) (RFrom (RTableRefSimple "s" Nothing)) RWhereEmpty RGroupByEmpty RHavingEmpty)
-    let ret2 = RQPushSelect (RSelect (RSel [RSelectItemProject (RExprBinOp "a-b" OpSub (RExprCol "a" Nothing "a") (RExprCol "b" Nothing "b")) Nothing]) (RFrom (RTableRefSimple "s" Nothing)) RWhereEmpty RGroupByEmpty RHavingEmpty)
-    parseAndRefine "select a-b from s emit changes;"   `shouldReturn` ret2
-    parseAndRefine "select a - b from s emit changes;" `shouldReturn` ret2

--- a/script/format.sh
+++ b/script/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $ bash script/format.sh ci
 

--- a/script/start-server.sh
+++ b/script/start-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 IMAGE=${IMAGE:-"docker.io/hstreamdb/haskell"}


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [x] Documentation updates required

### Summary of the change and which issue is fixed

Main changes: deny unquoted dash in ident


raw error

```
# can not parse
> select a->>"season_id" from production_changes EMIT CHANGES;
Parse exception at <line 1,column 11>: syntax error before `>'.

# generate wrong plan
> EXPLAIN SELECT a->b FROM s2;
-------- RAW PLAN --------
Project (name=a->b, alias=a->b) []
  Affiliate (name=a->b, expr=OpGT(#(a-), #(b))) 
    StreamScan s2
```


The above parse error and mistaken parse is caused by “a-“ is a valid HIdent, which is a valid simple col name, which is a val expr. If we add a space on the Left of arrow it will works.

`a->number` can be parsed as either “Extracts n'th element of JSON array (array elements are indexed from zero, but negative integers count from the end).“, the ColName a  > number. a->”str” can be parsed as select field “str“ or ColName a- compare to str

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
