### PR TITLE
Hadmin meta

### DIFF
--- a/hstream-admin/server/HStream/Admin/Server/Types.hs
+++ b/hstream-admin/server/HStream/Admin/Server/Types.hs
@@ -265,6 +265,7 @@ data MetaCommand
   = MetaCmdList Text
   | MetaCmdGet Text Text
   | MetaCmdTask MetaTaskCommand
+  | MetaCmdInfo
   deriving (Show)
 
 metaCmdParser :: O.Parser MetaCommand
@@ -283,6 +284,7 @@ metaCmdParser = O.subparser
                                                        <> O.metavar "RESOURCE_ID"
                                                        <> O.help "The Id of the resource"))
                             (O.progDesc "Get metadata of specific resource"))
+ <> O.command "info" (O.info (pure MetaCmdInfo) (O.progDesc "Get meta info"))
   ) O.<|> MetaCmdTask <$> metaTaskCmdParser
 
 data MetaTaskCommand

--- a/hstream-admin/server/HStream/Admin/Server/Types.hs
+++ b/hstream-admin/server/HStream/Admin/Server/Types.hs
@@ -261,17 +261,27 @@ connectorCmdParser = O.subparser
 
 -------------------------------------------------------------------------------
 
-data MetaCommand
+data MetaCommand 
   = MetaCmdList Text
+  | MetaCmdGet Text Text
   deriving (Show)
 
 metaCmdParser :: O.Parser MetaCommand
 metaCmdParser = O.subparser
-  ( O.command "List" (O.info (MetaCmdList <$> O.strOption ( O.long "resource"
+  ( O.command "list" (O.info (MetaCmdList <$> O.strOption ( O.long "resource"
                                                          <> O.short 'r'
                                                          <> O.metavar "RESOURCE_CATEGORY"
                                                          <> O.help "The category of the resource"))
                              (O.progDesc "List all metadata of specific resource"))
+ <> O.command "get" (O.info (MetaCmdGet <$> O.strOption ( O.long "resource"
+                                                       <> O.short 'r'
+                                                       <> O.metavar "RESOURCE_CATEGORY"
+                                                       <> O.help "The category of the resource")
+                                        <*> O.strOption ( O.long "id"
+                                                       <> O.short 'i'
+                                                       <> O.metavar "RESOURCE_ID"
+                                                       <> O.help "The Id of the resource"))
+                            (O.progDesc "Get metadata of specific resource"))
   )
 
 -------------------------------------------------------------------------------

--- a/hstream-admin/server/HStream/Admin/Server/Types.hs
+++ b/hstream-admin/server/HStream/Admin/Server/Types.hs
@@ -264,6 +264,7 @@ connectorCmdParser = O.subparser
 data MetaCommand 
   = MetaCmdList Text
   | MetaCmdGet Text Text
+  | MetaCmdTask MetaTaskCommand
   deriving (Show)
 
 metaCmdParser :: O.Parser MetaCommand
@@ -282,6 +283,23 @@ metaCmdParser = O.subparser
                                                        <> O.metavar "RESOURCE_ID"
                                                        <> O.help "The Id of the resource"))
                             (O.progDesc "Get metadata of specific resource"))
+  ) O.<|> MetaCmdTask <$> metaTaskCmdParser
+
+data MetaTaskCommand
+  = MetaTaskGet Text Text
+  deriving (Show)
+
+metaTaskCmdParser :: O.Parser MetaTaskCommand
+metaTaskCmdParser = O.subparser
+  ( O.command "get-task" (O.info (MetaTaskGet <$> O.strOption ( O.long "resource"
+                                                             <> O.short 'r'
+                                                             <> O.metavar "RESOURCE_CATEGORY"
+                                                             <> O.help "The category of the resource")
+                                              <*> O.strOption ( O.long "id"
+                                                             <> O.short 'i'
+                                                             <> O.metavar "RESOURCE_ID"
+                                                             <> O.help "The Id of the resource"))
+                            (O.progDesc "Get task allocation metadata of specific resource"))
   )
 
 -------------------------------------------------------------------------------

--- a/hstream-admin/server/HStream/Admin/Server/Types.hs
+++ b/hstream-admin/server/HStream/Admin/Server/Types.hs
@@ -203,7 +203,7 @@ data ViewCommand
   deriving (Show)
 
 viewCmdParser :: O.Parser ViewCommand
-viewCmdParser = O.subparser
+viewCmdParser = O.hsubparser
   ( O.command "list" (O.info (pure ViewCmdList) (O.progDesc "Get all views"))
   )
 
@@ -217,7 +217,7 @@ data QueryCommand
   deriving Show
 
 queryCmdParser :: O.Parser QueryCommand
-queryCmdParser = O.subparser
+queryCmdParser = O.hsubparser
   ( O.command "status" (O.info (QueryCmdStatus <$> O.strOption ( O.long "id"
                                                               <> O.short 'i'
                                                               <> O.metavar "QUERY_ID"
@@ -245,7 +245,7 @@ data ConnectorCommand
   deriving (Show)
 
 connectorCmdParser :: O.Parser ConnectorCommand
-connectorCmdParser = O.subparser
+connectorCmdParser = O.hsubparser
   ( O.command "list" (O.info (pure ConnectorCmdList) (O.progDesc "Get all connectors"))
  <> O.command "recover" (O.info (ConnectorCmdRecover <$> O.strOption ( O.long "id"
                                                                     <> O.short 'i'
@@ -261,7 +261,7 @@ connectorCmdParser = O.subparser
 
 -------------------------------------------------------------------------------
 
-data MetaCommand 
+data MetaCommand
   = MetaCmdList Text
   | MetaCmdGet Text Text
   | MetaCmdTask MetaTaskCommand
@@ -269,16 +269,18 @@ data MetaCommand
   deriving (Show)
 
 metaCmdParser :: O.Parser MetaCommand
-metaCmdParser = O.subparser
+metaCmdParser = O.hsubparser
   ( O.command "list" (O.info (MetaCmdList <$> O.strOption ( O.long "resource"
                                                          <> O.short 'r'
                                                          <> O.metavar "RESOURCE_CATEGORY"
-                                                         <> O.help "The category of the resource"))
+                                                         <> O.help ("The category of the resource, currently support: "
+                                                                 <> "[subscription|query-info|view-info|qv-relation]")))
                              (O.progDesc "List all metadata of specific resource"))
  <> O.command "get" (O.info (MetaCmdGet <$> O.strOption ( O.long "resource"
                                                        <> O.short 'r'
                                                        <> O.metavar "RESOURCE_CATEGORY"
-                                                       <> O.help "The category of the resource")
+                                                       <> O.help ("The category of the resource, currently support: "
+                                                                 <> "[subscription|query-info|query-status|view-info|qv-relation]"))
                                         <*> O.strOption ( O.long "id"
                                                        <> O.short 'i'
                                                        <> O.metavar "RESOURCE_ID"
@@ -292,7 +294,7 @@ data MetaTaskCommand
   deriving (Show)
 
 metaTaskCmdParser :: O.Parser MetaTaskCommand
-metaTaskCmdParser = O.subparser
+metaTaskCmdParser = O.hsubparser
   ( O.command "get-task" (O.info (MetaTaskGet <$> O.strOption ( O.long "resource"
                                                              <> O.short 'r'
                                                              <> O.metavar "RESOURCE_CATEGORY"
@@ -301,7 +303,7 @@ metaTaskCmdParser = O.subparser
                                                              <> O.short 'i'
                                                              <> O.metavar "RESOURCE_ID"
                                                              <> O.help "The Id of the resource"))
-                            (O.progDesc "Get task allocation metadata of specific resource"))
+                                 (O.progDesc "Get task allocation metadata of specific resource"))
   )
 
 -------------------------------------------------------------------------------

--- a/hstream-admin/server/HStream/Admin/Server/Types.hs
+++ b/hstream-admin/server/HStream/Admin/Server/Types.hs
@@ -95,6 +95,7 @@ data AdminCommand
   | AdminSubscriptionCommand SubscriptionCommand
   | AdminViewCommand ViewCommand
   | AdminQueryCommand QueryCommand
+  | AdminMetaCommand MetaCommand
   | AdminConnectorCommand ConnectorCommand
   | AdminStatusCommand
   | AdminInitCommand
@@ -118,6 +119,8 @@ adminCommandParser = O.hsubparser
                                (O.progDesc "View command"))
  <> O.command "query"  (O.info (AdminQueryCommand <$> queryCmdParser)
                                (O.progDesc "Query command"))
+ <> O.command "meta"   (O.info (AdminMetaCommand <$> metaCmdParser)
+                               (O.progDesc "Meta command"))
  <> O.command "status" (O.info (pure AdminStatusCommand)
                                (O.progDesc "Get the status of the HServer cluster"))
  <> O.command "init"   (O.info (pure AdminInitCommand)
@@ -254,6 +257,21 @@ connectorCmdParser = O.subparser
                                                                       <> O.metavar "CONNECTOR_ID"
                                                                       <> O.help "The ID of the connector"))
                                  (O.progDesc "Get the details of specific connector"))
+  )
+
+-------------------------------------------------------------------------------
+
+data MetaCommand
+  = MetaCmdList Text
+  deriving (Show)
+
+metaCmdParser :: O.Parser MetaCommand
+metaCmdParser = O.subparser
+  ( O.command "List" (O.info (MetaCmdList <$> O.strOption ( O.long "resource"
+                                                         <> O.short 'r'
+                                                         <> O.metavar "RESOURCE_CATEGORY"
+                                                         <> O.help "The category of the resource"))
+                             (O.progDesc "List all metadata of specific resource"))
   )
 
 -------------------------------------------------------------------------------

--- a/hstream/src/HStream/Server/Handler/Admin.hs
+++ b/hstream/src/HStream/Server/Handler/Admin.hs
@@ -246,14 +246,16 @@ getResType resType =
 runMeta :: ServerContext -> AT.MetaCommand -> IO Text
 runMeta ServerContext{..} (AT.MetaCmdList resType) = do
   case resType of
-    "subscription" -> pure <$> plainResponse . Text.pack . formatResult . map originSub =<< M.listMeta @SubscriptionWrap metaHandle
+    -- "subscription" -> pure <$> plainResponse . Text.pack . formatResult . map originSub =<< M.listMeta @SubscriptionWrap metaHandle
+    "subscription" -> pure <$> tableResponse . renderSubscriptionWrapToTable  =<< M.listMeta @SubscriptionWrap metaHandle
     "query-info" -> pure <$> plainResponse . renderQueryInfosToTable =<< M.listMeta @QueryInfo metaHandle
     "view-info" -> pure <$> plainResponse . renderViewInfosToTable =<< M.listMeta @ViewInfo metaHandle
     "qv-relation" -> pure <$> tableResponse . renderQVRelationToTable =<< M.listMeta @QVRelation metaHandle
     _ -> return $ errorResponse "unknown resource type"
 runMeta ServerContext{..} (AT.MetaCmdGet resType rId) = do
   case resType of
-    "subscription" -> pure <$> maybe (plainResponse "Not Found") (plainResponse . Text.pack . formatResult . originSub) =<< M.getMeta @SubscriptionWrap rId metaHandle
+    "subscription" -> pure <$> maybe (plainResponse "Not Found") (tableResponse . renderSubscriptionWrapToTable .L.singleton) =<< M.getMeta @SubscriptionWrap rId metaHandle
+    -- "subscription" -> pure <$> maybe (plainResponse "Not Found") (plainResponse . Text.pack . formatResult . originSub) =<< M.getMeta @SubscriptionWrap rId metaHandle
     "query-info" -> pure <$> maybe (plainResponse "Not Found") (plainResponse . renderQueryInfosToTable . L.singleton) =<< M.getMeta @QueryInfo rId metaHandle
     "query_status" -> pure <$> maybe (plainResponse "Not Found") (tableResponse . renderQueryStatusToTable . L.singleton) =<< M.getMeta @QueryStatus rId metaHandle
     "view-info" -> pure <$> maybe (plainResponse "Not Found") (plainResponse . renderViewInfosToTable . L.singleton) =<< M.getMeta @ViewInfo rId metaHandle

--- a/hstream/src/HStream/Server/Handler/Admin.hs
+++ b/hstream/src/HStream/Server/Handler/Admin.hs
@@ -252,11 +252,11 @@ runMeta ServerContext{..} (AT.MetaCmdList resType) = do
     _ -> return $ errorResponse "unknown resource type"
 runMeta ServerContext{..} (AT.MetaCmdGet resType rId) = do
   case resType of
-    "subscription" -> pure <$> maybe "" (plainResponse . Text.pack . formatResult . originSub) =<< M.getMeta @SubscriptionWrap rId metaHandle
-    "query-info" -> pure <$> maybe "" (plainResponse . renderQueryInfosToTable . L.singleton) =<< M.getMeta @QueryInfo rId metaHandle
-    "query_status" -> pure <$> maybe "" (tableResponse . renderQueryStatusToTable . L.singleton) =<< M.getMeta @QueryStatus rId metaHandle
-    "view-info" -> pure <$> maybe "" (plainResponse . renderViewInfosToTable . L.singleton) =<< M.getMeta @ViewInfo rId metaHandle
-    "qv-relation" -> pure <$> maybe "" (tableResponse . renderQVRelationToTable . L.singleton) =<< M.getMeta @QVRelation rId metaHandle
+    "subscription" -> pure <$> maybe (plainResponse "Not Found") (plainResponse . Text.pack . formatResult . originSub) =<< M.getMeta @SubscriptionWrap rId metaHandle
+    "query-info" -> pure <$> maybe (plainResponse "Not Found") (plainResponse . renderQueryInfosToTable . L.singleton) =<< M.getMeta @QueryInfo rId metaHandle
+    "query_status" -> pure <$> maybe (plainResponse "Not Found") (tableResponse . renderQueryStatusToTable . L.singleton) =<< M.getMeta @QueryStatus rId metaHandle
+    "view-info" -> pure <$> maybe (plainResponse "Not Found") (plainResponse . renderViewInfosToTable . L.singleton) =<< M.getMeta @ViewInfo rId metaHandle
+    "qv-relation" -> pure <$> maybe (plainResponse "Not Found") (tableResponse . renderQVRelationToTable . L.singleton) =<< M.getMeta @QVRelation rId metaHandle
     _ -> return $ errorResponse "unknown resource type"
 runMeta sc (AT.MetaCmdTask taskCmd) = runMetaTask sc taskCmd
 
@@ -265,7 +265,7 @@ runMetaTask ServerContext{..} (AT.MetaTaskGet resType rId) = do
   let metaId = mkAllocationKey (getResType resType) rId
   res <- M.getMeta @TaskAllocation metaId metaHandle
   Log.info $ "get metaId " <> Log.build metaId <> ", res = " <> Log.build (show res)
-  pure <$> maybe (plainResponse "Not Found.") (tableResponse . renderTaskAllocationsToTable . L.singleton) =<< M.getMeta @TaskAllocation metaId metaHandle
+  pure <$> maybe (plainResponse "Not Found") (tableResponse . renderTaskAllocationsToTable . L.singleton) =<< M.getMeta @TaskAllocation metaId metaHandle
 
 -------------------------------------------------------------------------------
 -- Admin Stream Command

--- a/hstream/src/HStream/Server/Handler/Admin.hs
+++ b/hstream/src/HStream/Server/Handler/Admin.hs
@@ -258,6 +258,14 @@ runMeta ServerContext{..} (AT.MetaCmdGet resType rId) = do
     "view-info" -> pure <$> maybe "" (plainResponse . renderViewInfosToTable . L.singleton) =<< M.getMeta @ViewInfo rId metaHandle
     "qv-relation" -> pure <$> maybe "" (tableResponse . renderQVRelationToTable . L.singleton) =<< M.getMeta @QVRelation rId metaHandle
     _ -> return $ errorResponse "unknown resource type"
+runMeta sc (AT.MetaCmdTask taskCmd) = runMetaTask sc taskCmd
+
+runMetaTask :: ServerContext -> AT.MetaTaskCommand -> IO Text
+runMetaTask ServerContext{..} (AT.MetaTaskGet resType rId) = do
+  let metaId = mkAllocationKey (getResType resType) rId
+  res <- M.getMeta @TaskAllocation metaId metaHandle
+  Log.info $ "get metaId " <> Log.build metaId <> ", res = " <> Log.build (show res)
+  pure <$> maybe (plainResponse "Not Found.") (tableResponse . renderTaskAllocationsToTable . L.singleton) =<< M.getMeta @TaskAllocation metaId metaHandle
 
 -------------------------------------------------------------------------------
 -- Admin Stream Command

--- a/hstream/src/HStream/Server/MetaData/Types.hs
+++ b/hstream/src/HStream/Server/MetaData/Types.hs
@@ -33,6 +33,7 @@ module HStream.Server.MetaData.Types
   , renderQueryStatusToTable
   , renderViewInfosToTable
   , renderQVRelationToTable
+  , renderTaskAllocationsToTable
   ) where
 
 import           Control.Exception                 (catches)
@@ -189,6 +190,12 @@ data ShardReaderMeta = ShardReaderMeta
 
 data TaskAllocation = TaskAllocation { taskAllocationEpoch :: Word32, taskAllocationServerId :: ServerID}
   deriving (Show, Generic, FromJSON, ToJSON)
+
+renderTaskAllocationsToTable :: [TaskAllocation] -> Aeson.Value
+renderTaskAllocationsToTable relations = 
+  let headers = ["Server ID" :: Text]
+      rows = map (\TaskAllocation{..} -> [taskAllocationServerId]) relations
+   in Aeson.object ["headers" Aeson..= headers, "rows" Aeson..= rows]
 
 rootPath :: Text
 rootPath = "/hstream"

--- a/hstream/src/HStream/Server/Types.hs
+++ b/hstream/src/HStream/Server/Types.hs
@@ -11,7 +11,7 @@ module HStream.Server.Types where
 import           Control.Concurrent               (MVar, ThreadId)
 import           Control.Concurrent.STM
 import           Data.Aeson                       (FromJSON (..), ToJSON (..))
-import qualified Data.Aeson as Aeson
+import qualified Data.Aeson                       as Aeson
 import qualified Data.HashMap.Strict              as HM
 import           Data.Int                         (Int32, Int64)
 import qualified Data.Map                         as Map
@@ -37,15 +37,16 @@ import           HStream.MetaStore.Types          (MetaHandle)
 import           HStream.Server.Config
 import           HStream.Server.ConnectorTypes    as HCT
 import           HStream.Server.HStreamApi        (NodeState, ResourceType,
-                                                   SpecialOffset (SpecialOffsetEARLIEST, SpecialOffsetLATEST),
+                                                   SpecialOffset (..),
                                                    StreamingFetchResponse,
-                                                   Subscription (Subscription, subscriptionSubscriptionId, subscriptionStreamName, subscriptionAckTimeoutSeconds, subscriptionMaxUnackedRecords, subscriptionCreationTime, subscriptionOffset))
+                                                   Subscription (..))
 import           HStream.Server.Shard             (ShardKey, SharedShardMap)
 import qualified HStream.Stats                    as Stats
 import qualified HStream.Store                    as HS
 import qualified HStream.Store                    as S
 import           HStream.Utils                    (ResourceType (ResConnector),
-                                                   textToCBytes)
+                                                   textToCBytes,
+                                                   timestampToMsTimestamp)
 
 protocolVersion :: Text
 protocolVersion = "0.1.0"
@@ -59,12 +60,12 @@ data SubscriptionWrap = SubscriptionWrap
   } deriving (Generic, Show, FromJSON, ToJSON)
 
 renderSubscriptionWrapToTable :: [SubscriptionWrap] -> Aeson.Value
-renderSubscriptionWrapToTable subs = 
-  let headers = ["Sub ID" :: Text, "Stream Name", "Ack Timeout", "Max Unacked Records", "Create Time", "Offset Type", "Offsets"]
+renderSubscriptionWrapToTable subs =
+  let headers = ["Sub ID" :: Text, "StreamName", "AckTimeout", "Max Unacked Records", "CreatedTime", "OffsetType", "Offsets"]
       rows = map formatSubscriptionWrap subs
    in Aeson.object ["headers" Aeson..= headers, "rows" Aeson..= rows]
  where
-   formatSubscriptionWrap SubscriptionWrap{originSub=Subscription{..}, ..} = 
+   formatSubscriptionWrap SubscriptionWrap{originSub=Subscription{..}, ..} =
      let offset = case subscriptionOffset of
                     (PB.Enumerated (Right SpecialOffsetEARLIEST)) -> "EARLIEST"
                     (PB.Enumerated (Right SpecialOffsetLATEST))   -> "LATEST"
@@ -73,9 +74,9 @@ renderSubscriptionWrapToTable subs =
          , subscriptionStreamName
          , T.pack . show $ subscriptionAckTimeoutSeconds
          , T.pack . show $ subscriptionMaxUnackedRecords
-         , maybe "" (T.pack . show) subscriptionCreationTime
+         , maybe "" (T.pack . show . timestampToMsTimestamp) subscriptionCreationTime
          , offset
-         , T.pack . show $ subOffsets
+         , T.pack . show . HM.toList $ subOffsets
          ]
 
 type Timestamp = Int64


### PR DESCRIPTION
# PR Description

## Type of change

- [x] New feature 

### Summary of the change and which issue is fixed

Main changes: 
- meta list -r [subscription|query-info|view-info|qv-relation]
```
hadmin server meta list -r subscription
+---------------------------------------------------+--------------------------------------------------------+------------+---------------------+---------------+------------+----------------------------------+
|                      Sub ID                       |                       StreamName                       | AckTimeout | Max Unacked Records |  CreatedTime  | OffsetType |             Offsets              |
+---------------------------------------------------+--------------------------------------------------------+------------+---------------------+---------------+------------+----------------------------------+
| __hstore_subscription_s1_cli_generated_ieslylycbi | s1                                                     | 600        | 100                 | 1685418459000 | LATEST     | [(1804208102078548,21474836481)] |
+---------------------------------------------------+--------------------------------------------------------+------------+---------------------+---------------+------------+----------------------------------+

hadmin server meta list -r query-info
{ queryId: cli_generated_jkivsxaalk, sql: create view v1 as select count(*) from s1 group by a;, createdTime: 1685418429, sourceStream: s1, sinkStream: v1, ast: RQCreate (RCreateView "v1" (RSelect (RSel [RSelectItemProject (RExprAggregate "COUNT(*)" COUNT(*)) Nothing]) (RFrom (RTableRefSimple "s1" Nothing)) RWhereEmpty (RGroupBy [(Nothing,"a")] Nothing) RHavingEmpty)), workNode: 1, type: CreateViewAs }
{ queryId: cli_generated_ieslylycbi, sql: CREATE STREAM cli_generated_stream_OtOZwmsfjKrMgChnconL AS select * from s1 ;, createdTime: 1685418459, sourceStream: s1, sinkStream: cli_generated_stream_OtOZwmsfjKrMgChnconL, ast: RQCreate (RCreateAs "cli_generated_stream_OtOZwmsfjKrMgChnconL" (RSelect (RSel [RSelectProjectAll]) (RFrom (RTableRefSimple "s1" Nothing)) RWhereEmpty RGroupByEmpty RHavingEmpty) (RStreamOptions {rRepFactor = 1, rBacklogDuration = 604800})), workNode: 1, type: CreateStreamAs }
```

- hadmin server meta get -r [subscription|query-info|view-info|qv-relation] --id resourceId

- hadmin server meta info
```
+-----------+-----------------+
| Meta Type | Connection Info |
+-----------+-----------------+
| zookeeper | 127.0.0.1:36903 |
+-----------+-----------------+
```

- hadmin server meta get-task -r query --id cli_generated_jkivsxaalk
```
+-----------+
| Server ID |
+-----------+
| 1.0       |
+-----------+
```
---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
