### PR TITLE
refactor data structures of inflight recordIds in subscription

### DIFF
--- a/hstream/hstream.cabal
+++ b/hstream/hstream.cabal
@@ -117,6 +117,7 @@ library
     , grpc-haskell-core
     , hashable
     , haskeline
+    , heaps
     , hs-grpc-server
     , hstream-admin-server
     , hstream-api-hs

--- a/hstream/src/HStream/Server/Core/Subscription.hs
+++ b/hstream/src/HStream/Server/Core/Subscription.hs
@@ -585,6 +585,23 @@ sendRecords ServerContext{..} subState subCtx@SubscribeContext {..} = do
         writeTVar subCurrentTime newTime
         writeTVar subWaitingCheckedRecordIds leftList
         return timeoutList
+      recordIds <- foldM
+                      (
+                        \acc CheckedRecordIds {..} -> do
+                          idxs <- readTVarIO crBatchIndexes
+                          let ids =
+                                    V.fromList $  fmap (\idx ->
+                                            RecordId {
+                                              recordIdShardId = crLogId
+                                            , recordIdBatchId = crBatchId
+                                            , recordIdBatchIndex = idx
+                                            }
+                                         ) (Set.toList idxs)
+                          pure $ acc V.++ ids
+                      )
+                      V.empty
+                      timeoutList
+      atomically $ removeAckedRecordIdsFromCheckList subCtx recordIds
       forM_ timeoutList (\r@CheckedRecordIds {..} -> buildShardRecordIds r >>= resendTimeoutRecords crLogId crBatchId )
       where
         buildShardRecordIds  CheckedRecordIds {..} = atomically $ do


### PR DESCRIPTION
- use `heap` intead of `list` for inflight recordsIds
- remove `subWaitingCheckedRecordIdsIndex` and simplify releated code

