### PR TITLE
cli: add read-stream command

### DIFF
--- a/common/hstream/HStream/Utils/Format.hs
+++ b/common/hstream/HStream/Utils/Format.hs
@@ -127,6 +127,8 @@ instance Format API.ListShardsResponse where
   formatResult = formatResult . V.toList . API.listShardsResponseShards
 instance Format API.ReadShardStreamResponse where
   formatResult = formatResult . V.toList . API.readShardStreamResponseReceivedRecords
+instance Format API.ReadStreamResponse where
+  formatResult = formatResult . V.toList . API.readStreamResponseReceivedRecords
 
 instance Format API.GetStreamResponse where
   formatResult = formatResult . maybeToList . API.getStreamResponseStream

--- a/hstream/src/HStream/Client/Action.hs
+++ b/hstream/src/HStream/Client/Action.hs
@@ -227,7 +227,6 @@ getSubscription sid HStreamApi{..} = hstreamApiGetSubscription $ mkClientNormalR
 executeViewQuery :: String -> Action ExecuteViewQueryResponse
 executeViewQuery sql HStreamApi{..} = hstreamApiExecuteViewQuery $ mkClientNormalRequest' def { executeViewQueryRequestSql = T.pack sql }
 
-
 streamReading :: Format a => IO (Either GRPCIOError (Maybe a)) -> IO ()
 streamReading recv = recv >>= \case
    Left (err :: GRPCIOError) -> errorWithoutStackTrace ("error: " <> show err)

--- a/hstream/src/HStream/Server/Core/ShardReader.hs
+++ b/hstream/src/HStream/Server/Core/ShardReader.hs
@@ -424,7 +424,6 @@ getResponseRecords
   -> IO (Vector API.ReceivedRecord)
 getResponseRecords reader shard records readerId startTs endTs = do
   let (records', isEnd) = filterRecords startTs endTs records
-  Log.debug $ "after filterRecords, isEnd = " <> Log.build (show isEnd)
   receivedRecordsVecs <- forM records' decodeRecordBatch
   let res = V.fromList $ map (\(_, _, _, record) -> record) receivedRecordsVecs
   Log.debug $ "reader " <> Log.build readerId

--- a/hstream/src/HStream/Server/Core/ShardReader.hs
+++ b/hstream/src/HStream/Server/Core/ShardReader.hs
@@ -387,8 +387,8 @@ filterRecords startTs endTs records =
   filterRecordAfterTimestamp rds timestamp =
      F.foldr'
        (
-          \r acc@(acc', _) -> let tmp = S.recordTimestamp r
-                               in if tmp <= timestamp then (r : acc', tmp == timestamp) else acc
+          \r (acc', isEnd) -> let tmp = S.recordTimestamp r
+                               in if tmp <= timestamp then (r : acc', isEnd || tmp == timestamp) else (acc', True)
        )
        ([], False)
        rds
@@ -424,6 +424,7 @@ getResponseRecords
   -> IO (Vector API.ReceivedRecord)
 getResponseRecords reader shard records readerId startTs endTs = do
   let (records', isEnd) = filterRecords startTs endTs records
+  Log.debug $ "after filterRecords, isEnd = " <> Log.build (show isEnd)
   receivedRecordsVecs <- forM records' decodeRecordBatch
   let res = V.fromList $ map (\(_, _, _, record) -> record) receivedRecordsVecs
   Log.debug $ "reader " <> Log.build readerId


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 
- [x] New feature 

### Summary of the change and which issue is fixed

Main changes: 
- cli support read-stream command
- fix: terminate serverStreaming when the timestamp of the record is greater than until timestamp

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
