### PR TITLE
fix dead lock when client send init before server already bootstrap

### DIFF
--- a/hstream-gossip/src/HStream/Gossip/Types.hs
+++ b/hstream-gossip/src/HStream/Gossip/Types.hs
@@ -54,7 +54,7 @@ data ServerState = ServerAlive | ServerSuspicious | ServerDead | ServerLeft
 --   | ServerFailed
 --   deriving (Show, Eq)
 
-data InitType = User | Gossip | Self
+data InitType = User | Gossip | Self deriving(Show)
 type Workers       = Map ServerId ThreadId
 type BroadcastPool = [(G.Message, Word32)]
 

--- a/hstream/app/server.hs
+++ b/hstream/app/server.hs
@@ -232,7 +232,7 @@ serveListeners
   -> ListenersSecurityProtocolMap
   -> Bool
   -- ^ Experimental features
-  -> IO ([Async.Async ()])
+  -> IO [Async.Async ()]
 serveListeners sc grpcOpts
                securityMap listeners listenerSecurityMap
                enableExpStreamV2 = do


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
