### PR TITLE
kafka: fix exception handle for delete topic and read latency tracking

### DIFF
--- a/hstream-kafka/HStream/Kafka/Common/Metrics/ConsumeStats.hs
+++ b/hstream-kafka/HStream/Kafka/Common/Metrics/ConsumeStats.hs
@@ -14,11 +14,11 @@ topicTotalSendMessages =
     P.Info "topic_messages_out" "Successfully read messages from a topic"
 {-# NOINLINE topicTotalSendMessages #-}
 
-readLatencySnd :: P.Histogram
-readLatencySnd =
-  P.unsafeRegister . P.histogram (P.Info "topic_read_latency" "topic read latency in second") $
+topicReadStoreLatency :: P.Histogram
+topicReadStoreLatency =
+  P.unsafeRegister . P.histogram (P.Info "topic_read_store_latency" "topic read store latency in second") $
       [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-{-# NOINLINE readLatencySnd #-}
+{-# NOINLINE topicReadStoreLatency #-}
 
 totalConsumeRequest :: P.Vector P.Label2 P.Counter
 totalConsumeRequest =

--- a/hstream-kafka/HStream/Kafka/Common/Metrics/ProduceStats.hs
+++ b/hstream-kafka/HStream/Kafka/Common/Metrics/ProduceStats.hs
@@ -14,11 +14,11 @@ topicTotalAppendMessages =
     P.Info "topic_messages_in" "Successfully appended messages for a topic"
 {-# NOINLINE topicTotalAppendMessages #-}
 
-appendLatencySnd :: P.Vector P.Label1 P.Histogram
-appendLatencySnd =
-  P.unsafeRegister . P.vector "topicName" . P.histogram (P.Info "topic_append_latency" "topic append latency in second") $
+topicWriteStoreLatency :: P.Vector P.Label1 P.Histogram
+topicWriteStoreLatency =
+  P.unsafeRegister . P.vector "topicName" . P.histogram (P.Info "topic_write_store_latency" "topic write store latency in second") $
       [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-{-# NOINLINE appendLatencySnd #-}
+{-# NOINLINE topicWriteStoreLatency #-}
 
 totalProduceRequest :: P.Vector P.Label2 P.Counter
 totalProduceRequest =

--- a/hstream-kafka/HStream/Kafka/Server/Handler/Consume.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Handler/Consume.hs
@@ -184,7 +184,7 @@ handleFetch ServerContext{..} _ r = K.catchFetchResponseEx $ do
          else S.readerSetTimeout reader r.maxWaitMs
       S.readerSetWaitOnlyWhenNoData reader
       (_, records) <- foldWhileM (0, []) $ \(size, acc) -> do
-        rs <- M.observeDuration M.readLatencySnd $ S.readerRead reader 100
+        rs <- M.observeDuration M.topicReadStoreLatency $ S.readerRead reader 100
         if null rs
            then pure ((size, acc), False)
            else do let size' = size + sum (map (K.recordBytesSize . (.recordPayload)) rs)
@@ -206,18 +206,18 @@ handleFetch ServerContext{..} _ r = K.catchFetchResponseEx $ do
            if r.maxWaitMs > defTimeout
               then do
                 S.readerSetTimeout reader defTimeout
-                rs1 <- M.observeDuration M.readLatencySnd $
+                rs1 <- M.observeDuration M.topicReadStoreLatency $
                           S.readerRead reader storageOpts.fetchMaxLen
                 let size = sum (map (K.recordBytesSize . (.recordPayload)) rs1)
                 if size >= fromIntegral r.minBytes
                    then pure rs1
                    else do S.readerSetTimeout reader (r.maxWaitMs - defTimeout)
-                           rs2 <- M.observeDuration M.readLatencySnd $
+                           rs2 <- M.observeDuration M.topicReadStoreLatency $
                                     S.readerRead reader storageOpts.fetchMaxLen
                            pure $ rs1 <> rs2
               else do
                 S.readerSetTimeout reader r.maxWaitMs
-                M.observeDuration M.readLatencySnd $ S.readerRead reader storageOpts.fetchMaxLen
+                M.observeDuration M.topicReadStoreLatency $ S.readerRead reader storageOpts.fetchMaxLen
 
 -------------------------------------------------------------------------------
 

--- a/hstream-kafka/HStream/Kafka/Server/Handler/Consume.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Handler/Consume.hs
@@ -212,11 +212,12 @@ handleFetch ServerContext{..} _ r = K.catchFetchResponseEx $ do
                 if size >= fromIntegral r.minBytes
                    then pure rs1
                    else do S.readerSetTimeout reader (r.maxWaitMs - defTimeout)
-                           rs2 <- S.readerRead reader storageOpts.fetchMaxLen
+                           rs2 <- M.observeDuration M.readLatencySnd $
+                                    S.readerRead reader storageOpts.fetchMaxLen
                            pure $ rs1 <> rs2
               else do
                 S.readerSetTimeout reader r.maxWaitMs
-                S.readerRead reader storageOpts.fetchMaxLen
+                M.observeDuration M.readLatencySnd $ S.readerRead reader storageOpts.fetchMaxLen
 
 -------------------------------------------------------------------------------
 

--- a/hstream-kafka/HStream/Kafka/Server/Handler/Produce.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Handler/Produce.hs
@@ -127,7 +127,7 @@ appendRecords shouldValidateCrc ldclient om (streamName, partition) logid bs = d
                                                  o (fromIntegral batchLength)
                                                  (K.CompactBytes storedBs)
     Log.debug1 $ "Append key " <> Log.buildString' appendKey
-    r <- M.observeWithLabel M.appendLatencySnd streamName $
+    r <- M.observeWithLabel M.topicWriteStoreLatency streamName $
            S.appendCompressedBS ldclient logid storedRecord S.CompressionNone
                                 appendAttrs
     let !partLabel = (streamName, T.pack . show $ partition)

--- a/hstream-kafka/HStream/Kafka/Server/Handler/Topic.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Handler/Topic.hs
@@ -104,5 +104,4 @@ handleDeleteTopicsV0 ServerContext{..} _ K.DeleteTopicsRequestV0{..} =
       V.forM_ partitions $ \(_, logid) ->
         cleanOffsetCache scOffsetManager logid
       S.removeStream scLDClient streamId
-      Stats.stream_stat_erase scStatsHolder (Utils.textToCBytes topicName)
       return $ K.DeletableTopicResultV0 topicName K.NONE


### PR DESCRIPTION
# PR Description

## Type of change

- [x] Bug fix 

### Summary of the change and which issue is fixed

Main changes: 
- fix incorrect errorCode:
  If two clients, a and b, perform the following operations concurrently: listTopic >>= deleteTopic, then in the delete handler, even if `S.doesStreamExist` returns true, the subsequent deletion may still throw a `NOTFOUND` exception. In this case, this exception would be incorrectly mapped to `UNKNOWN_SERVER_ERROR`, rather than `UNKNOWN_TOPIC_OR_PARTITION`.
- fix read latency tracking for consume handler

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
