### PR TITLE
hadmin-store: fix builds

### DIFF
--- a/cabal.project.hadmin.store
+++ b/cabal.project.hadmin.store
@@ -33,10 +33,11 @@ package thrift-cpp-channel
   tests: false
 
 constraints:
-    Z-IO          == 1.0.2.0
-  , Z-Data        == 1.3.0.1
-  , zoovisitor    == 0.2.5.1
-  , blaze-textual == 0.2.1.0
-  , entropy       == 0.4.1.7
-  , criterion    ^>= 1.6
-  , aeson         >=1.5   && <2.0
+    Z-IO                 == 1.0.2.0
+  , Z-Data               == 1.3.0.1
+  , zoovisitor           == 0.2.5.1
+  , blaze-textual        == 0.2.1.0
+  , entropy              == 0.4.1.7
+  , criterion           ^>= 1.6
+  , aeson                >=1.5   && <2.0
+  , unordered-containers < 0.2.20


### PR DESCRIPTION
constrain unordered-containers to < 0.2.20
