### PR TITLE
kafka: support set broker property from cli

### DIFF
--- a/conf/hstream.yaml
+++ b/conf/hstream.yaml
@@ -295,6 +295,8 @@ kafka:
   #
   #num.partitions: 1
   #default.replication.factor: 1
+  #auto.create.topic.enable: 1
+  #offsets.topic.replication.factor: 1
 
   # Internal storage options
   #

--- a/conf/hstream.yaml
+++ b/conf/hstream.yaml
@@ -295,7 +295,7 @@ kafka:
   #
   #num.partitions: 1
   #default.replication.factor: 1
-  #auto.create.topic.enable: 1
+  #auto.create.topic.enable: true
   #offsets.topic.replication.factor: 1
 
   # Internal storage options

--- a/hstream-kafka/HStream/Kafka/Group/GroupOffsetManager.hs
+++ b/hstream-kafka/HStream/Kafka/Group/GroupOffsetManager.hs
@@ -54,11 +54,11 @@ data GroupOffsetManager = forall os. OffsetStorage os => GroupOffsetManager
 
 -- FIXME: if we create a consumer group with groupName haven been used, call
 -- mkCkpOffsetStorage with groupName may lead us to a un-clean ckp-store
-mkGroupOffsetManager :: S.LDClient -> Int32 -> T.Text -> IO GroupOffsetManager
-mkGroupOffsetManager ldClient serverId groupName = do
+mkGroupOffsetManager :: S.LDClient -> Int32 -> T.Text -> Int -> IO GroupOffsetManager
+mkGroupOffsetManager ldClient serverId groupName offsetReplica = do
   offsetsCache  <- newIORef Map.empty
   partitionsMap <- newIORef Map.empty
-  offsetStorage <- mkCkpOffsetStorage ldClient groupName
+  offsetStorage <- mkCkpOffsetStorage ldClient groupName offsetReplica
   return GroupOffsetManager{..}
 
 loadOffsetsFromStorage :: GroupOffsetManager -> IO ()

--- a/hstream-kafka/HStream/Kafka/Group/OffsetsStore.hs
+++ b/hstream-kafka/HStream/Kafka/Group/OffsetsStore.hs
@@ -34,10 +34,10 @@ data CkpOffsetStorage = CkpOffsetStorage
   , trimCkpWorker :: !CompactedWorker
   }
 
-mkCkpOffsetStorage :: S.LDClient -> T.Text -> IO CkpOffsetStorage
-mkCkpOffsetStorage client ckpStoreName = do
+mkCkpOffsetStorage :: S.LDClient -> T.Text -> Int -> IO CkpOffsetStorage
+mkCkpOffsetStorage client ckpStoreName replica = do
   let cbGroupName = textToCBytes ckpStoreName
-      logAttrs = S.def{S.logReplicationFactor = S.defAttr1 1}
+      logAttrs = S.def{S.logReplicationFactor = S.defAttr1 replica}
   -- FIXME: need to get log attributes from somewhere
   S.initOffsetCheckpointDir client logAttrs
   ckpStoreId <- S.allocOffsetCheckpointId client cbGroupName

--- a/hstream-kafka/HStream/Kafka/Server/Config/FromJson.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Config/FromJson.hs
@@ -41,9 +41,10 @@ parseJSONToOptions CliOptions{..} obj = do
 
   -- Kafka config
   -- TODO: generate Parser from KafkaBrokerConfigs
-  let !_disableAutoCreateTopic = cliDisableAutoCreateTopic
-  let updateBrokerConfigs cfg = cfg {KC.autoCreateTopicsEnable=KC.AutoCreateTopicsEnable $ not _disableAutoCreateTopic}
-  !_kafkaBrokerConfigs <- updateBrokerConfigs <$> KC.parseBrokerConfigs nodeCfgObj
+  !_kafkaBrokerConfigs <- KC.mergeBrokerConfigs cliBrokerConfigs <$> KC.parseBrokerConfigs nodeCfgObj
+
+  b <- KC.parseBrokerConfigs nodeCfgObj
+
   metricsPort   <- nodeCfgObj .:? "metrics-port" .!= 9700
   let !_metricsPort = fromMaybe metricsPort cliMetricsPort
 

--- a/hstream-kafka/HStream/Kafka/Server/Config/FromJson.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Config/FromJson.hs
@@ -40,10 +40,7 @@ parseJSONToOptions CliOptions{..} obj = do
   nodeLogWithColor  <- nodeCfgObj .:? "log-with-color" .!= True
 
   -- Kafka config
-  -- TODO: generate Parser from KafkaBrokerConfigs
   !_kafkaBrokerConfigs <- KC.mergeBrokerConfigs cliBrokerConfigs <$> KC.parseBrokerConfigs nodeCfgObj
-
-  b <- KC.parseBrokerConfigs nodeCfgObj
 
   metricsPort   <- nodeCfgObj .:? "metrics-port" .!= 9700
   let !_metricsPort = fromMaybe metricsPort cliMetricsPort

--- a/hstream-kafka/HStream/Kafka/Server/Config/KafkaConfig.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Config/KafkaConfig.hs
@@ -61,7 +61,7 @@ instance KafkaConfig KafkaConfigInstance where
   defaultConfig = defaultConfig
 
 instance Show KafkaConfigInstance where
-  show i = T.unpack $ name i <> "=" <> value i
+  show (KafkaConfigInstance kc) = T.unpack . showConfig $ kc
 
 ---------------------------------------------------------------------------
 -- Kafka Topic Config
@@ -101,9 +101,11 @@ mkKafkaTopicConfigs configs = mkConfigs @KafkaTopicConfigs lk
 ---------------------------------------------------------------------------
 -- Kafka Broker Config
 ---------------------------------------------------------------------------
+showConfig :: KafkaConfig a => a -> T.Text
+showConfig c = name c <> "=" <> value c
 
 #define SHOWCONFIG(configType) \
-instance Show configType where { show c = T.unpack (name c) <> show (value c) }
+instance Show configType where { show = T.unpack . showConfig }
 
 newtype AutoCreateTopicsEnable = AutoCreateTopicsEnable { _value :: Bool } deriving (Eq)
 instance KafkaConfig AutoCreateTopicsEnable where

--- a/hstream-kafka/HStream/Kafka/Server/Config/KafkaConfig.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Config/KafkaConfig.hs
@@ -122,12 +122,21 @@ instance KafkaConfig DefaultReplicationFactor where
   fromText t = DefaultReplicationFactor <$> textToIntE t
   defaultConfig = DefaultReplicationFactor 1
 
+newtype OffsetsTopicReplicationFactor = OffsetsTopicReplicationFactor { _value :: Int } deriving (Eq)
+instance KafkaConfig OffsetsTopicReplicationFactor where
+  name = const "offsets.topic.replication.factor"
+  value (OffsetsTopicReplicationFactor v)  = T.pack $ show v
+  isSentitive = const False
+  fromText t = OffsetsTopicReplicationFactor <$> textToIntE t
+  defaultConfig = OffsetsTopicReplicationFactor 1
+
 data KafkaBrokerConfigs
   = KafkaBrokerConfigs
   { autoCreateTopicsEnable   :: AutoCreateTopicsEnable
   , numPartitions            :: NumPartitions
   , defaultReplicationFactor :: DefaultReplicationFactor
   } deriving (Show, Eq, G.Generic)
+  , offsetsTopicReplication  :: OffsetsTopicReplicationFactor
 instance KafkaConfigs KafkaBrokerConfigs
 
 parseBrokerConfigs :: Y.Object -> Y.Parser KafkaBrokerConfigs

--- a/hstream-kafka/HStream/Kafka/Server/Config/KafkaConfigManager.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Config/KafkaConfigManager.hs
@@ -73,7 +73,7 @@ getResultFromInstance (KC.KafkaConfigInstance cfg) =
     , isDefault=KC.isDefaultValue cfg
     , readOnly=KC.readOnly cfg
     , name=KC.name cfg
-    , value=KC.value cfg
+    , value= Just $ KC.value cfg
     }
 
 listBrokerConfigs :: KafkaConfigManager -> T.Text -> K.KaArray T.Text -> IO K.DescribeConfigsResult

--- a/hstream-kafka/HStream/Kafka/Server/Config/Types.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Config/Types.hs
@@ -75,7 +75,6 @@ data ServerOpts = ServerOpts
 
   , _maxRecordSize                :: !Int
   , _seedNodes                    :: ![(ByteString, Int)]
-  , _disableAutoCreateTopic       :: !Bool
 
   , _enableSaslAuth               :: !Bool
   , _enableAcl                    :: !Bool
@@ -142,8 +141,8 @@ data CliOptions = CliOptions
     -- ACL Authorization
   , cliEnableAcl                    :: !Bool
 
-    -- Kafka config
-  , cliDisableAutoCreateTopic       :: !Bool
+    -- Kafka broker config
+  , cliBrokerConfigs                :: !KC.KafkaBrokerConfigs
 
     -- HStream Experimental Features
   , cliExperimentalFeatures         :: ![ExperimentalFeature]

--- a/hstream-kafka/HStream/Kafka/Server/Types.hs
+++ b/hstream-kafka/HStream/Kafka/Server/Types.hs
@@ -61,8 +61,9 @@ initServerContext opts@ServerOpts{..} gossipContext mh = do
   -- XXX: Should we add a server option to toggle Stats?
   statsHolder <- newServerStatsHolder
   epochHashRing <- initializeHashRing gossipContext
-  scGroupCoordinator <- mkGroupCoordinator mh ldclient _serverID
 
+  let replica = _kafkaBrokerConfigs.offsetsTopicReplication._value
+  scGroupCoordinator <- mkGroupCoordinator mh ldclient _serverID replica
   -- must be initialized later
   offsetManager <- newOffsetManager ldclient
   -- Trick to avoid use maybe, must be initialized later

--- a/hstream/app/lib/KafkaServer.hs
+++ b/hstream/app/lib/KafkaServer.hs
@@ -80,6 +80,7 @@ runApp = do
 
 app :: ServerOpts -> IO ()
 app config@ServerOpts{..} = do
+  Log.info $ "start server with opts: " <> Log.build (show config)
   setupFatalSignalHandler
   S.setLogDeviceDbgLevel' _ldLogLevel
   let logType = case config.serverFileLog of


### PR DESCRIPTION
# PR Description

## Type of change

- [x] New feature 

### Summary of the change and which issue is fixed

Main changes:
- support set broker property from cli, e.g. --prop num.partitions=2 --prop auto.create.topics.enable=false
- support set offset topic replica

---

### Checklist

- I have run `format.sh` under `script`
- I have **comment**ed my code, particularly in hard-to-understand areas
- New and existing unit tests pass locally with my changes
